### PR TITLE
Upgrading NodeJS to lts/dubnium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     steps: &test_steps
       - checkout
       - run:
-          name: Install node@8.17.0 (need right version for `yarn`)
+          name: Install node@lts/dubnium (need right version for `yarn`)
           command: |
             set +e
             touch $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
             curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-            echo 'nvm install v8.17.0' >> $BASH_ENV
-            echo 'nvm alias default v8.17.0' >> $BASH_ENV
+            echo 'nvm install lts/dubnium' >> $BASH_ENV
+            echo 'nvm alias default lts/dubnium' >> $BASH_ENV
       - run:
           name: Check current version of node
           command: node -v


### PR DESCRIPTION
Otherwise CircleCI uses NodeJS for 8.x LTS releases.