### PR TITLE
Display digital objects as links if they aren't manifests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,9 @@ AllCops:
     - 'tmp/**/*'
 Metrics/BlockLength:
   Exclude:
+    - 'spec/**/*'
     - 'lib/tasks/plantain.rake'
     - 'app/controllers/catalog_controller.rb'
-    - 'spec/jobs/index_job_spec.rb'
-    - 'spec/features/traject/ead2_indexing_spec.rb'
     - 'config/routes.rb'
 Metrics/MethodLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - 'lib/tasks/plantain.rake'
-Metrics/ExampleLength:
+RSpec/ExampleLength:
   Exclude:
     - 'spec/features/traject/ead2_indexing_spec.rb'
 Style/StringLiterals:

--- a/app/overrides/arclight/digital_object_override.rb
+++ b/app/overrides/arclight/digital_object_override.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Add a role attribute to this class
+class Arclight::DigitalObject
+  attr_reader :role
+  def initialize(label:, href:, role:)
+    @label = label.present? ? label : href
+    @href = href
+    @role = role
+  end
+
+  def to_json(*)
+    { label: label, href: href, role: role }.to_json
+  end
+
+  def self.from_json(json)
+    object_data = JSON.parse(json)
+    new(label: object_data["label"], href: object_data["href"], role: object_data["role"])
+  end
+end

--- a/app/renderers/universal_viewer.rb
+++ b/app/renderers/universal_viewer.rb
@@ -1,22 +1,31 @@
 # frozen_string_literal: true
 class UniversalViewer
+  IIIF_MANIFEST_ROLE = "https://iiif.io/api/presentation"
+
+  attr_reader :document
   def initialize(document)
     @document = document
   end
 
   def to_partial_path
-    "viewers/_universal_viewer"
+    if digital_object.role&.starts_with? IIIF_MANIFEST_ROLE
+      "viewers/_universal_viewer"
+    else
+      "viewers/_simple_link"
+    end
   end
 
   def url
-    "#{base_url}#?manifest=#{manifest_url}"
+    "#{base_url}#?manifest=#{href}"
   end
 
   def base_url
     Plantain.config[:external_universal_viewer_url]
   end
 
-  def manifest_url
-    @document.digital_objects.first.href
+  def digital_object
+    document.digital_objects.first
   end
+  delegate :href, to: :digital_object
+  delegate :label, to: :digital_object
 end

--- a/app/views/viewers/_simple_link.html.erb
+++ b/app/views/viewers/_simple_link.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= link_to(viewer.label, viewer.href) %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,12 @@ module Plantain
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # load overrides
+    config.to_prepare do
+      Dir.glob(Rails.root.join("app", "**", "*_override*.rb")) do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
+    end
   end
 end

--- a/lib/plantain/traject/ead2_config.rb
+++ b/lib/plantain/traject/ead2_config.rb
@@ -208,7 +208,8 @@ to_field "digital_objects_ssm", extract_xpath("/ead/archdesc/did/dao|/ead/archde
     label = dao.attributes["title"]&.value ||
             dao.xpath("daodesc/p")&.text
     href = (dao.attributes["href"] || dao.attributes["xlink:href"])&.value
-    Arclight::DigitalObject.new(label: label, href: href).to_json
+    role = (dao.attributes["role"] || dao.attributes["xlink:role"])&.value
+    Arclight::DigitalObject.new(label: label, href: href, role: role).to_json
   end
 end
 
@@ -449,7 +450,8 @@ compose "components", ->(record, accumulator, _context) { accumulator.concat rec
       label = dao.attributes["title"]&.value ||
               dao.xpath("daodesc/p")&.text
       href = (dao.attributes["href"] || dao.attributes["xlink:href"])&.value
-      Arclight::DigitalObject.new(label: label, href: href).to_json
+      role = (dao.attributes["role"] || dao.attributes["xlink:role"])&.value
+      Arclight::DigitalObject.new(label: label, href: href, role: role).to_json
     end
   end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -52,8 +52,28 @@ describe "EAD 2 traject indexing", type: :feature do
           [
             JSON.generate(
               label: "https://figgy.princeton.edu/concern/scanned_resources/3359153c-82da-4078-ae51-e301f4c5e38b/manifest",
-              href: "https://figgy.princeton.edu/concern/scanned_resources/3359153c-82da-4078-ae51-e301f4c5e38b/manifest"
+              href: "https://figgy.princeton.edu/concern/scanned_resources/3359153c-82da-4078-ae51-e301f4c5e38b/manifest",
+              role: "https://iiif.io/api/presentation/2.1/"
             )
+          ]
+        )
+      end
+    end
+
+    context "when <dao> has no role" do
+      let(:fixture_path) do
+        Rails.root.join("spec", "fixtures", "ead", "mss", "WC064.EAD.xml")
+      end
+      let(:component) { result["components"].find { |c| c["id"] == ["WC064WC064_c11"] } }
+
+      it "gets the digital objects with role: null" do
+        json = JSON.generate(
+          label: "http://arks.princeton.edu/ark:/88435/vh53wv96d",
+          href: "http://arks.princeton.edu/ark:/88435/vh53wv96d"
+        ).slice(0..-2) + ",\"role\":null}"
+        expect(component["digital_objects_ssm"]).to eq(
+          [
+            json
           ]
         )
       end

--- a/spec/views/catalog/_arclight_viewer_default.html.erb_spec.rb
+++ b/spec/views/catalog/_arclight_viewer_default.html.erb_spec.rb
@@ -2,17 +2,36 @@
 require "rails_helper"
 
 RSpec.describe "catalog/_arclight_viewer_default.html.erb", type: :view do
-  let(:manifest_url) { "https://figgy.princeton.edu/concern/scanned_resources/3359153c-82da-4078-ae51-e301f4c5e38b/manifest" }
-  let(:document) do
-    SolrDocument.new(
-      digital_objects_ssm: [{ href: manifest_url }.to_json]
-    )
+  context "when the digital object is a manifest" do
+    let(:manifest_url) { "https://figgy.princeton.edu/concern/scanned_resources/3359153c-82da-4078-ae51-e301f4c5e38b/manifest" }
+    let(:document) do
+      SolrDocument.new(
+        digital_objects_ssm: [{ href: manifest_url, role: UniversalViewer::IIIF_MANIFEST_ROLE }.to_json]
+      )
+    end
+
+    it "renders universal viewer" do
+      assign(:document, document)
+      render
+      iframe = "<iframe src=\"https://figgy.princeton.edu/viewer#?manifest=#{manifest_url}\" allowfullscreen=\"true\"></iframe>"
+      expect(rendered).to include iframe
+    end
   end
 
-  it "renders universal viewer" do
-    assign(:document, document)
-    render
-    iframe = "<iframe src=\"https://figgy.princeton.edu/viewer#?manifest=#{manifest_url}\" allowfullscreen=\"true\"></iframe>"
-    expect(rendered).to include iframe
+  context "when the digital object is a link" do
+    let(:ark_url) { "http://arks.princeton.edu/ark:/88435/vh53wv96d" }
+    let(:json) { "{\"label\":\"#{ark_url}\",\"href\":\"#{ark_url}\",\"role\":null}" }
+    let(:document) do
+      SolrDocument.new(
+        digital_objects_ssm: [json]
+      )
+    end
+
+    it "renders a link" do
+      assign(:document, document)
+      render
+      link = "<a href=\"#{ark_url}\">#{ark_url}</a>"
+      expect(rendered).to include link
+    end
   end
 end


### PR DESCRIPTION
refs #162 

looks like this now for non-manifest objects:

![Screen Shot 2020-03-24 at 8 54 59 AM](https://user-images.githubusercontent.com/845363/77428068-e0697980-6dad-11ea-9203-15e62b343ba4.png)
