### PR TITLE
Do not index DSC[2].

### DIFF
--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -258,7 +258,7 @@ to_field "descrules_ssm", extract_xpath("/ead/eadheader/profiledesc/descrules")
 # =============================
 
 # rubocop:disable Metrics/BlockLength
-compose "components", ->(record, accumulator, _context) { accumulator.concat record.xpath("//dsc[1]//*[is_component(.)]", NokogiriXpathExtensions.new) } do
+compose "components", ->(record, accumulator, _context) { accumulator.concat record.xpath("//dsc[@type='combined']//*[is_component(.)]", NokogiriXpathExtensions.new) } do
   to_field "ref_ssi" do |record, accumulator, context|
     accumulator << if record.attribute("id").blank?
                      strategy = Arclight::MissingIdStrategy.selected

--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -258,7 +258,7 @@ to_field "descrules_ssm", extract_xpath("/ead/eadheader/profiledesc/descrules")
 # =============================
 
 # rubocop:disable Metrics/BlockLength
-compose "components", ->(record, accumulator, _context) { accumulator.concat record.xpath("//*[is_component(.)]", NokogiriXpathExtensions.new) } do
+compose "components", ->(record, accumulator, _context) { accumulator.concat record.xpath("//dsc[1]//*[is_component(.)]", NokogiriXpathExtensions.new) } do
   to_field "ref_ssi" do |record, accumulator, context|
     accumulator << if record.attribute("id").blank?
                      strategy = Arclight::MissingIdStrategy.selected

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -51,6 +51,16 @@ describe "EAD 2 traject indexing", type: :feature do
     end
   end
 
+  describe "container indexing" do
+    let(:fixture_path) do
+      Rails.root.join("spec", "fixtures", "ead", "C0002.xml")
+    end
+    it "doesn't index them as components" do
+      components = result["components"]
+      expect(components.group_by { |x| x["id"].first }["C0002_i1"]).to be_blank
+    end
+  end
+
   describe "digital objects" do
     context "when <dao> is child of the <did> in a <c0x> component" do
       let(:component) { result["components"].find { |c| c["id"] == ["MC221_c0094"] } }

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -57,6 +57,7 @@ describe "EAD 2 traject indexing", type: :feature do
     end
     it "doesn't index them as components" do
       components = result["components"]
+      expect(components.length).to eq 10
       expect(components.group_by { |x| x["id"].first }["C0002_i1"]).to be_blank
     end
   end

--- a/spec/fixtures/ead/C0002.xml
+++ b/spec/fixtures/ead/C0002.xml
@@ -1,0 +1,261 @@
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd" audience="external">
+  <eadheader xmlns:xlink="http://www.w3.org/1999/xlink" scriptencoding="iso15924" repositoryencoding="iso15511" countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b">
+    <eadid mainagencycode="US-NjP" countrycode="US" url="http://arks.princeton.edu/ark:/88435/7h149p936" urn="ark:/88435/7h149p936">C0002</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>
+          Penelope Pennington Collection,
+          <date normal="1798/1827" type="inclusive">1798-1827</date>
+            : Finding Aid
+        </titleproper>
+      </titlestmt>
+      <publicationstmt id="rbscAddress">
+        <publisher>Princeton University Library. Special Collections.</publisher>
+        <address>
+          <addressline>Manuscripts Division</addressline>
+          <addressline>One Washington Road</addressline>
+          <addressline>Princeton, New Jersey 08544 USA</addressline>
+          <addressline>Phone: (609) 258-3184</addressline>
+          <addressline>Fax: (609) 258-2324</addressline>
+          <addressline>rbsc@princeton.edu</addressline>
+          <addressline>http://www.princeton.edu/~rbsc</addressline>
+        </address>
+        <date normal="2008">2008</date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>
+        This finding aid was produced using the Archivists' Toolkit
+        <date normal="2012-05-21">2012-05-21T11:25-0400</date>
+      </creation>
+      <langusage>
+        <language langcode="eng"/>
+      </langusage>
+      <descrules>
+        Finding aid content adheres to that prescribed by
+        <emph render="italic"> Describing Archives: A Content Standard. </emph>
+      </descrules>
+    </profiledesc>
+    <revisiondesc>
+      <change>
+        <date normal="2012-05-21">2012-05-21T12:00:07.548-04:00</date>
+        <item>Run through PULFA 2.0 normalization routines.</item>
+      </change>
+    </revisiondesc>
+  </eadheader>
+  <archdesc xmlns:xlink="http://www.w3.org/1999/xlink" level="collection" relatedencoding="marc21" type="findingaid">
+    <did>
+      <unitid countrycode="US" repositorycode="US-NjP" type="collection">C0002</unitid>
+      <repository id="mss">
+        <corpname source="viaf" authfilenumber="http://viaf.org/viaf/168350386">Princeton University Library. Special Collections.</corpname>
+        <subarea>Manuscripts Division</subarea>
+        <address>
+          <addressline>One Washington Road</addressline>
+          <addressline>Princeton, New Jersey 08544 USA</addressline>
+        </address>
+      </repository>
+      <unittitle>Penelope Pennington Collection</unittitle>
+      <unitdate normal="1798/1827" type="inclusive">1798-1827</unitdate>
+      <physdesc>
+        <extent>0.2 linear feet</extent>
+        <extent unit="boxes">1 half-size archival box</extent>
+      </physdesc>
+      <origination>
+        <persname source="lcsh" role="cre">Pennington, Penelope, 1752?-1827.</persname>
+      </origination>
+      <langmaterial>
+        <language langcode="eng"/>
+      </langmaterial>
+      <abstract>
+        Consists of selected letters and manuscripts of Penelope Pennington, who was part of the social and literary women's group that was centered around the English diarist and patron of the arts Hester Lynch Thrale Piozzii (1741-1821).
+      </abstract>
+      <physloc type="code">mss</physloc>
+    </did>
+    <bioghist>
+      <p>
+        Penelope Pennington was a friend and correspondent of Hester Lynch Thrale Piozzi, Mrs. Siddons, and Anna Seward.
+      </p>
+    </bioghist>
+    <descgrp id="dacs3">
+      <scopecontent>
+        <p>
+          The collection consists of thirty-one letters by Mrs. Pennington, mostly to her younger friend Maria Brown, whose relationship to Mrs. Pennington somewhat paralleled that of Mrs. Pennington to Mrs. Piozzi (Hester Lynch Thrale Piozzi); the autograph manuscript of Mrs. Pennington's poem "The Copper Farthing"; and over 200 pages of material, mostly in Mrs. Pennington's hand, largely copies of poems by her friends and literary quotations which apparently served the purpose of a commonplace book. The gossipy letters comment on politics, criticize books just read, and complain about bad health--not unlike letters of Mrs. Piozzi. Specific topics include the deaths of Maria Siddons and Mrs. Piozzi, Byron's poetry, and the peace of 1814.
+        </p>
+      </scopecontent>
+    </descgrp>
+    <descgrp id="dacs4">
+      <accessrestrict type="open">
+        <p>The collection is open for research.</p>
+      </accessrestrict>
+      <userestrict>
+        <p>
+          Single photocopies may be made for research purposes. No further photoduplication of copies of material in the collection can be made when Princeton University Library does not own the original. Inquiries regarding publishing material from the collection should be directed to RBSC Public Services staff at rbsc@princeton.edu. The library has no information on the status of literary rights in the collection and researchers are responsible for determining any questions of copyright.
+        </p>
+      </userestrict>
+    </descgrp>
+    <descgrp id="dacs5">
+      <acqinfo>
+        <p>
+          Three gifts: two from Robert F. Metzdorf in 1958 and 1961 and one from Mrs. Knight Woolley in 1958. Additional purchase in 1969.
+        </p>
+      </acqinfo>
+      <appraisal>
+        <p>No appraisal information is available.</p>
+      </appraisal>
+    </descgrp>
+    <descgrp id="dacs7">
+      <prefercite>
+        <p>
+          Identification of specific item; Date (if known); Penelope Pennington Collection, Box and Folder Number; Special Collections, Princeton University Library.
+        </p>
+      </prefercite>
+      <processinfo type="processing">
+        <p>
+          This collection was processed by
+          <name role="processor">Lauren Hoffman</name>
+            in
+          <date normal="2012-05-21" type="processed">May 2012</date>
+            . Finding aid written by
+          <name role="author">Lauren Hoffman</name>
+            in
+          <date normal="2012-05-21" type="processed">May 2012</date>
+            .
+        </p>
+      </processinfo>
+    </descgrp>
+    <controlaccess>
+      <persname source="lcsh">Brown, Maria, 18th cent.</persname>
+      <persname source="lcsh">
+        Piozzi, Hester Lynch, 1741-1821 -- Friends and associates.
+      </persname>
+      <genreform source="aat">Commonplace books -- England -- 19th century.</genreform>
+      <subject rules="local" source="local" encodinganalog="690" authfilenumber="t16">British literature</subject>
+      <subject rules="local" source="local" encodinganalog="690" authfilenumber="t56">Women's studies</subject>
+    </controlaccess>
+    <dsc type="combined">
+      <c id="C0002_c001" level="file">
+        <did>
+          <unittitle>Letters to Maria Brown and Others, 1798-1814</unittitle>
+          <container type="folder" parent="C0002_i1">1</container>
+          <unitdate normal="1798/1814" type="inclusive">1798-1814</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+        <scopecontent>
+          <p>Contains 5 AMs letters.</p>
+        </scopecontent>
+      </c>
+      <c id="C0002_c002" level="file">
+        <did>
+          <unittitle>Letters to Maria Brown and Others, 1817-1821</unittitle>
+          <container type="folder" parent="C0002_i1">2</container>
+          <unitdate normal="1817/1821" type="inclusive">1817-1821</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+        <scopecontent>
+          <p>Contains 14 AMs letters.</p>
+        </scopecontent>
+      </c>
+      <c id="C0002_c003" level="file">
+        <did>
+          <unittitle>Letters to Maria Brown and Others, 1822-1827</unittitle>
+          <container type="folder" parent="C0002_i1">3</container>
+          <unitdate normal="1822/1827" type="inclusive">1822-1827</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+        <scopecontent>
+          <p>Contains 12 AMs letters.</p>
+        </scopecontent>
+      </c>
+      <c id="C0002_c004" level="file">
+        <did>
+          <unittitle>AMs, "The Copper Farthing," a poem, 7 p.</unittitle>
+          <container type="folder" parent="C0002_i1">4</container>
+          <unitdate>undated</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+      </c>
+      <c id="C0002_c005" level="file">
+        <did>
+          <unittitle>AMs from Commonplace Books, 1744-1789</unittitle>
+          <container type="folder" parent="C0002_i1">5</container>
+          <unitdate normal="1744/1789" type="inclusive">1744-1789</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+      </c>
+      <c id="C0002_c006" level="file">
+        <did>
+          <unittitle>AMs from Commonplace Books, Undated (1)</unittitle>
+          <container type="folder" parent="C0002_i1">6</container>
+          <unitdate>undated</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+      </c>
+      <c id="C0002_c007" level="file">
+        <did>
+          <unittitle>AMs from Commonplace Books, Undated (2)</unittitle>
+          <container type="folder" parent="C0002_i1">7</container>
+          <unitdate>undated</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+      </c>
+      <c id="C0002_c008" level="file">
+        <did>
+          <unittitle>AMs from Commonplace Books, Undated (3)</unittitle>
+          <container type="folder" parent="C0002_i1">8</container>
+          <unitdate>undated</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+      </c>
+      <c id="C0002_c009" level="file">
+        <did>
+          <unittitle>AMs from Commonplace Books, Undated (4)</unittitle>
+          <container type="folder" parent="C0002_i1">9</container>
+          <unitdate>undated</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+      </c>
+      <c id="C0002_c010" level="file">
+        <did>
+          <unittitle>Thorpe, James: Writings about Penelope Pennington</unittitle>
+          <container type="folder" parent="C0002_i1">10</container>
+          <unitdate normal="1960/1960">1960</unitdate>
+          <physdesc>
+            <extent type="computed" unit="folders">1 folder</extent>
+          </physdesc>
+        </did>
+        <scopecontent>
+          <p>
+            Essay about Pennington is from The Princeton University Library Chronicle.
+          </p>
+        </scopecontent>
+      </c>
+    </dsc>
+    <dsc type="othertype" othertype="physicalholdings">
+      <c level="otherlevel" otherlevel="physicalitem" id="C0002_i1">
+        <did>
+          <container type="box">1</container>
+          <unitid type="barcode">32101040679134</unitid>
+          <physloc type="code">mss</physloc>
+        </did>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>


### PR DESCRIPTION
Later we'll have to put the containers into the source documents, but
for now don't recognize them as top-level components.