### PR TITLE
Don't leave search fields as Nokogiri Nodes

### DIFF
--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -230,13 +230,13 @@ to_field "date_range_sim", extract_xpath("/ead/archdesc/did/unitdate/@normal", t
 end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == "prefercite"
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}")
 end
 
 NAME_ELEMENTS.map do |selector|
@@ -509,12 +509,12 @@ compose "components", ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']")
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
     to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
+    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}")
   end
   to_field "did_note_ssm", extract_xpath("./did/note")
 end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -60,6 +60,11 @@ describe "EAD 2 traject indexing", type: :feature do
       expect(components.length).to eq 10
       expect(components.group_by { |x| x["id"].first }["C0002_i1"]).to be_blank
     end
+    it "doesn't leave empty arrays around" do
+      component = result.as_json["components"][1]
+
+      expect(component["scopecontent_ssm"]).to eq ["Contains 14 AMs letters."]
+    end
   end
 
   describe "digital objects" do


### PR DESCRIPTION
Without an accumulator there's no reason to not convert them to text. In fact, leaving them as not text results in empty fields.

Closes #203