### PR TITLE
Ensuring that the overidden DigitalObject is used by Traject for indexing

### DIFF
--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -10,7 +10,7 @@ require "arclight/normalized_date"
 require "arclight/normalized_title"
 require "active_model/conversion" ## Needed for Arclight::Repository
 require "active_support/core_ext/array/wrap"
-require "arclight/digital_object"
+require Rails.root.join("app", "overrides", "arclight", "digital_object_override")
 require "arclight/year_range"
 require "arclight/repository"
 require "arclight/missing_id_strategy"


### PR DESCRIPTION
Resolves #245 and deprecates #248 