### PR TITLE
Generates "preferred citation" fields for Collections and Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,10 @@ follow Capistrano task:
 ```bash
 bundle exec cap staging pulfalight:index_pulfa
 ```
+
+### Citation Formatting
+
+Citations are generated for collections and components, and rendered on the
+show page for either of these resources. The default formatted repository
+sources may be found and updated within the appropriate [configuration
+file](./config/citations.yml).

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -52,6 +52,10 @@ class SolrDocument
     fetch("ead_ssi", [])
   end
 
+  def eadid
+    Array.wrap(super).first
+  end
+
   def title
     fetch("title_ssm", [])
   end

--- a/app/services/citation_resolver_service.rb
+++ b/app/services/citation_resolver_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CitationResolverService
+  def self.config_path
+    Rails.root.join("config", "citations.yml")
+  end
+
+  def self.citation_values
+    config = File.read(config_path)
+    document = YAML.parse(config)
+    document.to_ruby
+  end
+
+  def self.resolve(repository_id:)
+    return unless citation_values.key?(repository_id)
+
+    citation_values[repository_id]
+  end
+end

--- a/config/citations.yml
+++ b/config/citations.yml
@@ -1,0 +1,10 @@
+--- # Please see the README for an overview of configuring citation formatting
+eng: Technical and Scientific Reports, Engineering Library
+lae: Latin American Ephemera Collections
+selectors: Selectors
+cotsen: Cotsen Children's Library, Department of Special Collections
+mss: Manuscripts Division, Department of Special Collections
+publicpolicy: Public Policy Papers, Department of Special Collections
+univarchives: Princeton University Archives, Department of Special Collections
+rarebooks: Rare Book Division, Department of Special Collections
+ga: Graphic Arts Collection, Department of Special Collections

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -118,6 +118,20 @@ selectors:
   thumbnail_url: "https://findingaids.princeton.edu/repositories/mss.jpg"
   visit_note: ""
 
+selectors:
+  name: 'General Collections'
+  description: "General Collections are teaching and research collections acquired by Princeton University Library subject selectors. The collections cover a wide range of topics related to Princeton University Library's collecting areas."
+  building: 'Firestone Library'
+  address1: 'General Collections'
+  address2: 'One Washington Road'
+  city: 'Princeton'
+  state: 'NJ'
+  zip: '08544'
+  country: 'USA'
+  phone: '(609) 258-1470'
+  contact_info: 'refdesk [at] princeton [dot] edu'
+  thumbnail_url: "https://findingaids.princeton.edu/repositories/mss.jpg"
+
 univarchives:
   name: 'Princeton University Archives'
   building: 'Seeley G. Mudd Manuscript Library'

--- a/lib/pulfalight/traject/ead2_component_config.rb
+++ b/lib/pulfalight/traject/ead2_component_config.rb
@@ -305,6 +305,26 @@ Pulfalight::Ead2Indexing::DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
 end
 to_field "did_note_ssm", extract_xpath("./did/note")
 
+to_field "prefercite_ssm" do |_record, accumulator, context|
+  parent = context.clipboard[:parent] || settings[:parent]
+  parent_ids = parent.output_hash["id"]
+  parent_id = parent_ids.first
+  parent_titles = parent.output_hash["title_ssm"]
+  parent_title = parent_titles.first
+  output = "#{parent_title}, #{parent_id}, "
+  citation = CitationResolverService.resolve(repository_id: settings["repository"])
+  if citation
+    output += citation
+    output += ", Princeton University Library"
+
+    accumulator << output unless output.empty?
+  end
+end
+
+to_field "prefercite_teim" do |_record, accumulator, context|
+  accumulator.concat Array.wrap(context.output_hash["prefercite_ssm"])
+end
+
 to_field "components" do |record, accumulator, _context|
   child_components = record.xpath("./*[is_component(.)][@level != 'otherlevel']", NokogiriXpathExtensions.new)
   child_components.each do |child_component|

--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -188,7 +188,7 @@ end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
-  to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == "prefercite"
+  to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head")
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
@@ -208,6 +208,23 @@ to_field "language_sim", extract_xpath("/ead/archdesc/did/langmaterial")
 to_field "language_ssm", extract_xpath("/ead/archdesc/did/langmaterial")
 
 to_field "descrules_ssm", extract_xpath("/ead/eadheader/profiledesc/descrules")
+
+to_field "prefercite_ssm" do |_record, accumulator, context|
+  titles = context.output_hash["title_ssm"]
+  title = titles.first
+  output = "#{title}; "
+  citation = CitationResolverService.resolve(repository_id: settings["repository"])
+  if citation
+    output += citation
+    output += ", Princeton University Library"
+
+    accumulator << output unless output.empty?
+  end
+end
+
+to_field "prefercite_teim" do |_record, accumulator, context|
+  accumulator.concat Array.wrap(context.output_hash["prefercite_ssm"])
+end
 
 to_field "components" do |record, accumulator, context|
   xpath = if record.is_a?(Nokogiri::XML::Document)

--- a/lib/pulfalight/traject/ead2_indexing.rb
+++ b/lib/pulfalight/traject/ead2_indexing.rb
@@ -60,7 +60,7 @@ module Pulfalight
 
     def build_component_indexer(context)
       config_file_path = Rails.root.join("lib", "pulfalight", "traject", "ead2_component_config.rb")
-      indexer_settings = { parent: context }
+      indexer_settings = { parent: context, repository: settings["repository"] }
       Traject::Indexer::NokogiriIndexer.new(indexer_settings).tap do |i|
         i.load_config_file(config_file_path)
       end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -11,9 +11,10 @@ describe "EAD 2 traject indexing", type: :feature do
 
   let(:settings) do
     {
-      "repository" => "publicpolicy"
+      repository: "publicpolicy"
     }
   end
+
   let(:indexer) do
     Traject::Indexer::NokogiriIndexer.new(settings).tap do |i|
       i.load_config_file(Rails.root.join("lib", "pulfalight", "traject", "ead2_config.rb"))
@@ -119,7 +120,7 @@ describe "EAD 2 traject indexing", type: :feature do
     context "when <dao> has no role" do
       let(:settings) do
         {
-          "repository" => "mss"
+          repository: "mss"
         }
       end
       let(:fixture_path) do

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -9,38 +9,30 @@ describe "EAD 2 traject indexing", type: :feature do
     indexer.map_record(record)
   end
 
+  let(:settings) do
+    {
+      "repository" => "publicpolicy"
+    }
+  end
   let(:indexer) do
-    Traject::Indexer::NokogiriIndexer.new.tap do |i|
+    Traject::Indexer::NokogiriIndexer.new(settings).tap do |i|
       i.load_config_file(Rails.root.join("lib", "pulfalight", "traject", "ead2_config.rb"))
     end
   end
-
   let(:fixture_file) do
     File.read(fixture_path)
   end
-
   let(:nokogiri_reader) do
     Arclight::Traject::NokogiriNamespacelessReader.new(fixture_file.to_s, indexer.settings)
   end
-
   let(:records) do
     nokogiri_reader.to_a
   end
-
   let(:record) do
     records.first
   end
-
   let(:fixture_path) do
     Rails.root.join("spec", "fixtures", "ead", "mudd", "publicpolicy", "MC221_pruned.EAD.xml")
-  end
-
-  before do
-    ENV["REPOSITORY_ID"] = nil
-  end
-
-  after do # ensure we reset these otherwise other tests will fail
-    ENV["REPOSITORY_ID"] = nil
   end
 
   describe "solr fields" do
@@ -52,16 +44,10 @@ describe "EAD 2 traject indexing", type: :feature do
   end
 
   describe "repository indexing" do
-    context "when a Repository model has been persisted before the collection is indexed" do
-      let(:repository_name) { "Test Repository" }
-      let(:repository) { Arclight::Repository.create(name: repository_name) }
-      before do
-        ENV["REPOSITORY_FILE"] = Rails.root.join("spec", "fixtures", "repositories.yml").to_s
-        ENV["REPOSITORY_ID"] = "nlm"
-      end
+    context "when a Repository has been before the collection is indexed" do
       it "retrieves an existing Repository model and indexes this into Solr" do
-        expect(result).to include("repository_ssm" => ["National Library of Medicine. History of Medicine Division"])
-        expect(result).to include("repository_sim" => ["National Library of Medicine. History of Medicine Division"])
+        expect(result).to include("repository_ssm" => ["Public Policy Papers"])
+        expect(result).to include("repository_sim" => ["Public Policy Papers"])
       end
     end
   end
@@ -131,6 +117,11 @@ describe "EAD 2 traject indexing", type: :feature do
     end
 
     context "when <dao> has no role" do
+      let(:settings) do
+        {
+          "repository" => "mss"
+        }
+      end
       let(:fixture_path) do
         Rails.root.join("spec", "fixtures", "ead", "mss", "WC064_pruned.EAD.xml")
       end
@@ -198,6 +189,22 @@ describe "EAD 2 traject indexing", type: :feature do
         result["title_ssm"][0],
         result["normalized_date_ssm"][0]
       )
+    end
+  end
+
+  describe "generating citations" do
+    it "generates a citation for any given collection" do
+      expect(result).to include("prefercite_ssm" => ["Harold B. Hoskins Papers; Public Policy Papers, Department of Special Collections, Princeton University Library"])
+      expect(result).to include("prefercite_teim" => ["Harold B. Hoskins Papers; Public Policy Papers, Department of Special Collections, Princeton University Library"])
+    end
+
+    it "generates a citation for any given component" do
+      expect(result).to include("components")
+      components = result["components"]
+      expect(components).not_to be_empty
+      component = components.first
+      expect(component).to include("prefercite_ssm" => ["Harold B. Hoskins Papers, MC221, Public Policy Papers, Department of Special Collections, Princeton University Library"])
+      expect(component).to include("prefercite_teim" => ["Harold B. Hoskins Papers, MC221, Public Policy Papers, Department of Special Collections, Princeton University Library"])
     end
   end
 end


### PR DESCRIPTION
Implementing support for indexing the generated citations for EAD collections and components using the `prefercite` field; Ensuring that this is rendered on the show views for both Collections and Components. Resolves #150. 

Please see the following example:
![image](https://user-images.githubusercontent.com/1443986/80529203-18dc1480-8965-11ea-9f96-4c6acd61a5d3.png)
