### PR TITLE
Ensuring that users are redirected to the show page when searching for a valid collection ID

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -38,6 +38,20 @@ class CatalogController < ApplicationController
     end
   end
 
+  def index
+    query_param = params.fetch(:q)
+    return super unless query_param =~ /^[A-Z]{1,2}\d{3,4}$/
+
+    # Try and take the user directly to the show page
+    begin
+      _deprecated_response, @document = search_service.fetch(query_param)
+    rescue Blacklight::Exceptions::RecordNotFound
+      return super
+    end
+
+    redirect_to solr_document_path(id: @document)
+  end
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/spec/requests/catalog_request_spec.rb
+++ b/spec/requests/catalog_request_spec.rb
@@ -166,4 +166,34 @@ describe "controller requests", type: :request do
       expect(response.body).to include("Harold B. Hoskins Papers; Public Policy Papers, Department of Special Collections, Princeton University Library")
     end
   end
+
+  describe "searching all collections" do
+    let(:query) { "WC064" }
+
+    before do
+      repository = Blacklight.default_index
+      repository.connection.add(document)
+      repository.connection.commit
+
+      allow(Blacklight::SearchService).to receive(:new).and_call_original
+      get "/catalog?q=#{query}"
+    end
+
+    after do
+      repository = Blacklight.default_index
+      repository.connection.delete_by_id(document.id)
+      repository.connection.commit
+    end
+
+    context "when searching for a specific collection by ID" do
+      it "directs the user to the exact collection if it exists" do
+        expect(response).to redirect_to(solr_document_url(document.id))
+      end
+
+      it "directs the user to the search results if it does not exist" do
+        get "/catalog?q=WC063"
+        expect(response.body).to include("Search Results")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ensuring that, when users search for a collection ID, that they are redirected to the collection show page (should the collection exist). Advances #79 