### PR TITLE
Ensuring that users are redirected to the show page when searching for a valid collection ID

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -38,6 +38,20 @@ class CatalogController < ApplicationController
     end
   end
 
+  def index
+    query_param = params.fetch(:q)
+    return super unless query_param =~ /^[A-Z]{1,2}\d{3,4}$/
+
+    # Try and take the user directly to the show page
+    begin
+      _deprecated_response, @document = search_service.fetch(query_param)
+    rescue Blacklight::Exceptions::RecordNotFound
+      return super
+    end
+
+    redirect_to solr_document_path(id: @document)
+  end
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -39,7 +39,7 @@ class CatalogController < ApplicationController
   end
 
   def index
-    query_param = params.fetch(:q)
+    query_param = params[:q]
     return super unless query_param =~ /^[A-Z]{1,2}\d{3,4}$/
 
     # Try and take the user directly to the show page

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,12 +43,12 @@ class CatalogController < ApplicationController
     return super unless query_param =~ /^[A-Z]{1,2}\d{3,4}$/
 
     # Try and take the user directly to the show page
-    begin
-      _deprecated_response, @document = search_service.fetch(query_param)
-    rescue Blacklight::Exceptions::RecordNotFound
-      return super
-    end
+    server_response = Blacklight.default_index.connection.get("select", params: { q: query_param })
+    solr_response = server_response["response"]
+    docs = solr_response["docs"]
+    return super if docs.empty?
 
+    @document = SolrDocument.new(docs.first)
     redirect_to solr_document_path(id: @document)
   end
 

--- a/spec/requests/catalog_request_spec.rb
+++ b/spec/requests/catalog_request_spec.rb
@@ -168,7 +168,7 @@ describe "controller requests", type: :request do
   end
 
   describe "searching all collections" do
-    let(:query) { "WC064" }
+    let(:query) { "C1588" }
 
     before do
       repository = Blacklight.default_index
@@ -176,7 +176,6 @@ describe "controller requests", type: :request do
       repository.connection.commit
 
       allow(Blacklight::SearchService).to receive(:new).and_call_original
-      get "/catalog?q=#{query}"
     end
 
     after do
@@ -187,6 +186,7 @@ describe "controller requests", type: :request do
 
     context "when searching for a specific collection by ID" do
       it "directs the user to the exact collection if it exists" do
+        get "/catalog?q=#{query}"
         expect(response).to redirect_to(solr_document_url(document.id))
       end
 

--- a/spec/requests/catalog_request_spec.rb
+++ b/spec/requests/catalog_request_spec.rb
@@ -194,6 +194,13 @@ describe "controller requests", type: :request do
         get "/catalog?q=WC063"
         expect(response.body).to include("Search Results")
       end
+
+      context "when no query is provided" do
+        it "directs to the default search page" do
+          get "/catalog?q="
+          expect(response.body).to include("Use this site to explore descriptions of our unique holdings at the Princeton University Libraries")
+        end
+      end
     end
   end
 end

--- a/spec/requests/catalog_request_spec.rb
+++ b/spec/requests/catalog_request_spec.rb
@@ -166,4 +166,34 @@ describe "controller requests", type: :request do
       expect(response.body).to include("Harold B. Hoskins Papers; Public Policy Papers, Department of Special Collections, Princeton University Library")
     end
   end
+
+  describe "searching all collections" do
+    let(:query) { "WC064" }
+
+    before do
+      repository = Blacklight.default_index
+      repository.connection.add(document)
+      repository.connection.commit
+
+      allow(Blacklight::SearchService).to receive(:new).and_call_original
+      get "/catalog?q=#{query}"
+    end
+
+    after do
+      repository = Blacklight.default_index
+      repository.connection.delete_by_id(document.id)
+      repository.connection.commit
+    end
+
+    context "when searching for a specific collection by ID" do
+      it "directs the user to the exact collection if it exists" do
+        expect(response).to redirect_to(solr_document_url(document.id))
+      end
+
+      it "directs the user to the search results if it does not exist" do
+        get "/catalog?q=WC063"
+        expect(response.body).to include("Search Results")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ensuring that, when users search for a collection ID, that they are redirected to the collection show page (should the collection exist). Advances #79