### PR TITLE
Implements a Rake Task for checking out PULFA EADs exported from ArchivesSpace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ yarn-debug.log*
 .yarn-integrity
 
 /eads/pulfa
+/eads/aspace_fa
 /public/robots.txt
 
 # This seems to be an artifact left from SVN when checking out the PULFA repository

--- a/lib/tasks/pulfa.rake
+++ b/lib/tasks/pulfa.rake
@@ -23,6 +23,38 @@ namespace :pulfa do
     exit(exit_code)
   end
 
+  namespace :aspace do
+    desc "Check out ArchiveSpace EAD examples"
+    task :checkout do
+      check_if_lpass_installed
+      check_if_logged_in
+
+      lastpass_pulfa_svn_username = "Shared-ITIMS-Passwords/pulfa_svn_username"
+      lastpass_pulfa_svn_password = "Shared-ITIMS-Passwords/pulfa_svn_password"
+      lastpass_pulfa_svn_url = "Shared-ITIMS-Passwords/pulfa_aspace_eads_svn_url"
+
+      username = `lpass show --notes #{lastpass_pulfa_svn_username}`
+      username.chomp!
+
+      # Get block of username and passwords
+      user_pass = `lpass show --notes #{lastpass_pulfa_svn_password}`
+
+      # Split into key value pairs and convert to hash
+      passwords = user_pass.split("\n").map { |p| p.split(":") }.to_h
+
+      # Get password associated with primary username
+      password = passwords[username]
+
+      svn_url = `lpass show --notes #{lastpass_pulfa_svn_url}`
+      svn_url.chomp!
+
+      cmd = "/usr/bin/env svn checkout #{svn_url} eads/aspace_fa/ --username #{username} --non-interactive --password #{password}"
+
+      exit_code = system(cmd)
+      exit(exit_code)
+    end
+  end
+
   # Utility methods
 
   # Determine if the lpass binary is installed and in the $PATH


### PR DESCRIPTION
This is necessary in order to advance #278 