### PR TITLE
Fix spec regressions and remove unneeded comment

### DIFF
--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -244,8 +244,6 @@ to_field "collection_notes_ssm" do |record, accumulator, _context|
   child_elements = child_nodes.select { |c| c.is_a?(Nokogiri::XML::Element) }
   parse_nested_text = lambda do |node|
     text_nodes = []
-    # I was getting a strange error with the Nokogiri API when attempting this
-    # children = node.children.select { |c| c.is_a?(Nokogiri::XML:Element) }
     children = if node.name == "did"
                  node.xpath("./abstract").select { |c| c.class == Nokogiri::XML::Element }
                elsif node.name == "descgrp" && node["id"] == "dacs7"

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -206,6 +206,10 @@ describe "EAD 2 traject indexing", type: :feature do
     end
 
     describe "collection notes indexing" do
+      let(:fixture_path) do
+        Rails.root.join("spec", "fixtures", "ead", "mudd", "publicpolicy", "MC221.EAD.xml")
+      end
+
       it "indexes all note fields from the <archdesc> child elements for the collection" do
         expect(result).to include("collection_notes_ssm")
         expect(result["collection_notes_ssm"]).not_to be_empty


### PR DESCRIPTION
- Unless this is helpful for developers of the future.
- Also fixes a regression in a spec that was introduced in a previous commit. Branch needed to be rebased before merging.
