### PR TITLE
Remove redundant tab titles

### DIFF
--- a/app/assets/stylesheets/layouts/catalog_show.scss
+++ b/app/assets/stylesheets/layouts/catalog_show.scss
@@ -127,6 +127,10 @@
           column-gap: 0.8rem;
         }
 
+        .document-info {
+          padding-top: 1.2rem;
+        }
+
         .document-title {
           border-bottom: 3px solid #dee2e6;
 

--- a/app/views/catalog/_collection_access.html.erb
+++ b/app/views/catalog/_collection_access.html.erb
@@ -1,7 +1,4 @@
-<div class="overview">
-  <div class="document-title">
-    <h3>Access</h3>
-  </div>
+<div class="overview document-info">
   <% metadata = :access_field %>
   <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
   <dl>

--- a/app/views/catalog/_collection_description.html.erb
+++ b/app/views/catalog/_collection_description.html.erb
@@ -1,7 +1,4 @@
-<div class="overview">
-  <div class="document-title">
-    <h3>Collection Description</h3>
-  </div>
+<div class="overview document-info">
   <% metadata = :collection_description_field %>
   <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
   <dl>

--- a/app/views/catalog/_collection_find_more.html.erb
+++ b/app/views/catalog/_collection_find_more.html.erb
@@ -1,7 +1,4 @@
-<div class="overview">
-  <div class="document-title">
-    <h3>Find Related Materials</h3>
-  </div>
+<div class="overview document-info">
   <% metadata = :indexed_terms_field %>
   <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
   <dl>

--- a/app/views/catalog/_collection_history.html.erb
+++ b/app/views/catalog/_collection_history.html.erb
@@ -1,7 +1,4 @@
-<div class="overview">
-  <div class="document-title">
-    <h3>Collection History</h3>
-  </div>
+<div class="overview document-info">
   <% metadata = :collection_history_field %>
   <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
   <dl>

--- a/app/views/catalog/_collection_summary.html.erb
+++ b/app/views/catalog/_collection_summary.html.erb
@@ -1,6 +1,6 @@
 <div class="overview">
   <div class="document-title">
-    <h3>Summary</h3>
+    <h3>Collection Overview</h3>
   </div>
   <%= render(partial: 'collection_summary_overview') %>
   <%= render(partial: 'collection_summary_abstract') %>

--- a/app/views/catalog/_collection_summary_overview.html.erb
+++ b/app/views/catalog/_collection_summary_overview.html.erb
@@ -1,5 +1,4 @@
-<h4>Overview</h4>
-<dl class="al-metadata-section breadcrumb-item breadcrumb-item-3">
+<dl>
   <% metadata = :summary_field %>
   <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
   <% generic_document_fields(metadata).each do |field_name, field| %>


### PR DESCRIPTION
- Remove redundant tab titles
- Reformats collection overview page slightly to better match tab name

Closes #394 

<img width="1421" alt="Screen Shot 2020-10-01 at 11 59 31 AM" src="https://user-images.githubusercontent.com/784196/94840641-5ba38c00-03de-11eb-8829-a88c95acc4c1.png">
<img width="1406" alt="Screen Shot 2020-10-01 at 12 03 17 PM" src="https://user-images.githubusercontent.com/784196/94840648-5d6d4f80-03de-11eb-9e22-d43a5814a841.png">
