### PR TITLE
Adds LUX announcements Banner

### DIFF
--- a/app/assets/stylesheets/modules/header.scss
+++ b/app/assets/stylesheets/modules/header.scss
@@ -1,6 +1,10 @@
 @import 'variables/colors';
 
 header {
+  .lux-announcement {
+    @extend .alert-info;
+  }
+
   .lux-library-header[data-v-22f7d1b2] {
     background-color: $black-pul;
 
@@ -179,5 +183,4 @@ header {
   .dropdown-toggle a {
     color: $dark-gray;
   }
-
 }

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,5 +1,5 @@
 <header class="lux">
-  <banner dismissible>
+  <banner>
     <h2>Fall Semester Announcements</h2>
     <p>We’re currently in beta for students and will be introducing faculty, advisor and staff functionality in the coming months.</p>
   </banner>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,8 @@
 <header class="lux">
+  <banner dismissible>
+    <h2>Fall Semester Announcements</h2>
+    <p>We’re currently in beta for students and will be introducing faculty, advisor and staff functionality in the coming months.</p>
+  </banner>
   <library-header app-name="<%= application_name %>" app-url="<%= root_path %>">
     <div class="menu--level-1 d-none d-md-block col-md-2 col-lg-3">
       <div class="cart-view-toggle-block">
@@ -14,7 +18,7 @@
       <nav class="container" role="navigation">
         <% if on_home_page? %>
           <div class="row pt-lg-5">
-            <h1 class="ml-auto mr-auto">Explore Princeton's Archival Collections</h2>
+            <h1 class="ml-auto mr-auto">Explore Princeton's Archival Collections</h1>
           </div>
         <% end %>
         <div class="row<%= " pb-lg-5 pb-2" if on_home_page? %>">


### PR DESCRIPTION
@tpendragon One thing that I didn't add to the LUX component is a cookie that knows if you've dismissed the banner, so we don't show it on subsequent pages. If that's desirable, I'll add it. Otherwise, I will remove the "dismissible" attribute and the banner will be ever-present. 