### PR TITLE
446 clear cart

### DIFF
--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -4,125 +4,137 @@
 
   <div v-if="isVisible" :class="['request-cart']">
 
-    <form method="post" :action="configuration.url">
-      <div v-if="requests.length" class="panel">
-        <table :class="['lux-data-table']">
+    <div v-if="requests.length" class="panel">
+      <table :class="['lux-data-table']">
 
-          <caption>
+        <caption>
 
-            <input-button
-              v-on:button-clicked="toggleCartView($event)"
-              type="button"
-              variation="text"
-              class="denied-button"
-              aria-labelledby="denied"
-              >
+          <input-button
+            v-on:button-clicked="toggleCartView($event)"
+            type="button"
+            variation="text"
+            class="denied-button"
+            aria-labelledby="denied"
+            >
 
-              <div class="lux-icon">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 16 16"
-                  aria-labelledby="denied"
-                  role="img"
-                  fill="#6e757c"
-                  >
-                  <title id="denied" lang="en">denied</title>
-                  <x-circle-icon></x-circle-icon>
-                </svg>
-              </div>
-            </input-button>
-
-            <div class="caption-title">
-              <span>Request Cart</span>
-              <lux-icon-base width="30" height="30" icon-name="Cart">
-                <lux-icon-cart></lux-icon-cart>
-              </lux-icon-base>
-            </div>
-            <div class="caption-note">
-              Add items from multiple pages and request them all at once.
-            </div>
-          </caption>
-
-          <thead>
-            <tr>
-              <th>Title</th>
-              <th>Call Number</th>
-              <th colspan="2">Containers</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <template v-for="(item, index) in requests">
-
-              <tr
-                :key="index"
-                :id="'item-' + item.callnumber"
-                class="lux-cartItem request"
+            <div class="lux-icon">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                viewBox="0 0 16 16"
+                aria-labelledby="denied"
+                role="img"
+                fill="#6e757c"
                 >
-                <td>{{ item.title }}</td>
-                <td>{{ item.callnumber }}</td>
-                <td>
-                  {{ item.containers }}
-                </td>
-                <td>
-                  <input-button
-                    @button-clicked="removeFromCart(item)"
-                    type="button"
-                    variation="outline"
-                    >
-                    Remove
-                  </input-button>
-                </td>
-              </tr>
+                <title id="denied" lang="en">denied</title>
+                <x-circle-icon></x-circle-icon>
+              </svg>
+            </div>
+          </input-button>
 
-              <tr v-if="item.location" class="request__location">
-                <td colspan="4">
-                  <geo-icon></geo-icon>
-                  View this item at the <a :href="item.location.url">Mudd Library Reading Room</a>
-                </td>
-              </tr>
+          <div class="caption-title">
+            <span>Request Cart</span>
+            <lux-icon-base width="30" height="30" icon-name="Cart">
+              <lux-icon-cart></lux-icon-cart>
+            </lux-icon-base>
+          </div>
+          <div class="caption-note">
+            Add items from multiple pages and request them all at once.
+          </div>
+        </caption>
 
-              <tr v-if="item.location && item.location.notes" class="request__location-notes">
-                <td colspan="4">
-                  <truck-icon></truck-icon>
-                  {{ item.location.notes }}
-                </td>
-              </tr>
-            </template>
-          </tbody>
-        </table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Call Number</th>
+            <th colspan="2">Containers</th>
+          </tr>
+        </thead>
 
-        <div class="hidden">
-          <template v-for="(request, requestIndex) in requests">
-            <template v-for="(form_values, field_name) in request.formParams">
-              <input :id="field_name" :name="field_name" type="hidden"
-                                                         :value="form_values"></input>
-            </template>
+        <tbody>
+          <template v-for="(item, index) in requests">
+
+            <tr
+              :key="index"
+              :id="'item-' + item.callnumber"
+              class="lux-cartItem request"
+              >
+              <td>{{ item.title }}</td>
+              <td>{{ item.callnumber }}</td>
+              <td>
+                {{ item.containers }}
+              </td>
+              <td>
+                <input-button
+                  @button-clicked="removeFromCart(item)"
+                  type="button"
+                  variation="outline"
+                  >
+                  Remove
+                </input-button>
+              </td>
+            </tr>
+
+            <tr v-if="item.location" class="request__location">
+              <td colspan="4">
+                <geo-icon></geo-icon>
+                View this item at the <a :href="item.location.url">Mudd Library Reading Room</a>
+              </td>
+            </tr>
+
+            <tr v-if="item.location && item.location.notes" class="request__location-notes">
+              <td colspan="4">
+                <truck-icon></truck-icon>
+                {{ item.location.notes }}
+              </td>
+            </tr>
           </template>
-        </div>
+        </tbody>
+      </table>
 
-      </div><!-- /.panel -->
-      <div v-else class="panel">
-        <heading level="h3">Your cart is currently empty.</heading>
-      </div>
+    </div><!-- /.panel -->
+    <div v-else class="panel">
+      <heading level="h3">Your cart is currently empty.</heading>
+    </div>
 
-      <div class="cart-actions">
-        <div class="center">
+    <div class="cart-actions">
+      <div class="center">
+        <form id="request-cart-form" method="post" :action="configuration.url"
+                                     v-on:submit.prevent="clearForm">
+          <div class="hidden">
+            <template v-for="(request, requestIndex) in requests">
+              <template v-for="(form_values, field_name) in request.formParams">
+                <input :id="field_name" :name="field_name" type="hidden"
+                                                           :value="form_values"></input>
+              </template>
+            </template>
+          </div>
+
           <input-button type="submit" variation="solid" :disabled="requests.length == 0" block>
             {{ requestButtonText() }}
           </input-button>
-        </div>
+        </form>
       </div>
+    </div>
 
+    <form id="shadow-form" method="post" :action="configuration.url"
+                           ref="shadowForm">
+      <div class="hidden">
+        <template v-for="(request, requestIndex) in shadowRequests">
+          <template v-for="(form_values, field_name) in request.formParams">
+            <input :id="field_name" :name="field_name" type="hidden"
+                                                       :value="form_values"></input>
+          </template>
+        </template>
+      </div>
     </form>
+
   </div>
   </transition>
 </template>
 
 <script>
-import store from "../store"
 import { mapState, mapGetters } from "vuex"
 import LuxIconCart from './RequestCartIcon.vue'
 import GeoIcon from './GeoIcon.vue'
@@ -138,6 +150,11 @@ export default {
     'x-circle-icon': XCircleIcon,
     'request-form-input': RequestFormInput
   },
+  data() {
+    return {
+      shadowRequests: []
+    }
+  },
   props: {
     configuration: {
       type: Object,
@@ -147,19 +164,16 @@ export default {
   },
   computed: {
     requests() {
-      return this.cart.items
+      return this.$store.state.cart.items
     },
     isVisible: {
       get() {
-        return this.cart.isVisible
+        return this.$store.state.cart.isVisible
       },
       set() {
-        store.commit("TOGGLE_VISIBILITY")
+        this.$store.commit("TOGGLE_VISIBILITY")
       }
-    },
-    ...mapState({
-      cart: state => store.state.cart,
-    })
+    }
   },
   methods: {
     displayContainers(containers) {
@@ -183,11 +197,19 @@ export default {
       return text
     },
     removeFromCart(item) {
-      store.dispatch("removeItemFromCart", item)
+      this.$store.dispatch("removeItemFromCart", item)
     },
     toggleCartView(event) {
-      store.commit("TOGGLE_VISIBILITY")
+      this.$store.commit("TOGGLE_VISIBILITY")
     },
+    clearForm() {
+      this.shadowRequests = this.requests
+      this.$store.commit("SET_CART", [])
+      // ensure shadowform is re-rendered with items before submission
+      this.$nextTick(() => {
+        this.$refs.shadowForm.submit()
+      })
+    }
   }
 }
 </script>

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -4,45 +4,45 @@
 
   <div v-if="isVisible" :class="['request-cart']">
 
-      <form method="post" :action="configuration.url">
-    <div v-if="requests.length" class="panel">
+    <form method="post" :action="configuration.url">
+      <div v-if="requests.length" class="panel">
         <table :class="['lux-data-table']">
 
           <caption>
 
-    <input-button
-      v-on:button-clicked="toggleCartView($event)"
-      type="button"
-      variation="text"
-      class="denied-button"
-      aria-labelledby="denied"
-    >
+            <input-button
+              v-on:button-clicked="toggleCartView($event)"
+              type="button"
+              variation="text"
+              class="denied-button"
+              aria-labelledby="denied"
+              >
 
-      <div class="lux-icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          viewBox="0 0 16 16"
-          aria-labelledby="denied"
-          role="img"
-          fill="#6e757c"
-          >
-          <title id="denied" lang="en">denied</title>
-          <x-circle-icon></x-circle-icon>
-        </svg>
-      </div>
-    </input-button>
+              <div class="lux-icon">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="1em"
+                  height="1em"
+                  viewBox="0 0 16 16"
+                  aria-labelledby="denied"
+                  role="img"
+                  fill="#6e757c"
+                  >
+                  <title id="denied" lang="en">denied</title>
+                  <x-circle-icon></x-circle-icon>
+                </svg>
+              </div>
+            </input-button>
 
-    <div class="caption-title">
-      <span>Request Cart</span>
-      <lux-icon-base width="30" height="30" icon-name="Cart">
-        <lux-icon-cart></lux-icon-cart>
-      </lux-icon-base>
-    </div>
-    <div class="caption-note">
-      Add items from multiple pages and request them all at once.
-    </div>
+            <div class="caption-title">
+              <span>Request Cart</span>
+              <lux-icon-base width="30" height="30" icon-name="Cart">
+                <lux-icon-cart></lux-icon-cart>
+              </lux-icon-base>
+            </div>
+            <div class="caption-note">
+              Add items from multiple pages and request them all at once.
+            </div>
           </caption>
 
           <thead>
@@ -60,7 +60,7 @@
                 :key="index"
                 :id="'item-' + item.callnumber"
                 class="lux-cartItem request"
-              >
+                >
                 <td>{{ item.title }}</td>
                 <td>{{ item.callnumber }}</td>
                 <td>
@@ -98,30 +98,27 @@
           <template v-for="(request, requestIndex) in requests">
             <template v-for="(form_values, field_name) in request.formParams">
               <input :id="field_name" :name="field_name" type="hidden"
-              :value="form_values"></input>
+                                                         :value="form_values"></input>
             </template>
           </template>
         </div>
 
-    </div><!-- /.panel -->
-    <div v-else class="panel">
-      <heading level="h3">Your cart is currently empty.</heading>
-    </div>
-
-        <div class="cart-actions">
-          <div class="center">
-            <input-button type="submit" variation="solid" :disabled="requests.length == 0" block>
-              {{ requestButtonText() }}
-            </input-button>
-          </div>
-        </div>
-
-      </form>
-
+      </div><!-- /.panel -->
+      <div v-else class="panel">
+        <heading level="h3">Your cart is currently empty.</heading>
       </div>
 
-  </transition>
+      <div class="cart-actions">
+        <div class="center">
+          <input-button type="submit" variation="solid" :disabled="requests.length == 0" block>
+            {{ requestButtonText() }}
+          </input-button>
+        </div>
+      </div>
 
+    </form>
+  </div>
+  </transition>
 </template>
 
 <script>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
   },
   "jest": {
     "verbose": true,

--- a/spec/javascript/pulfalight/cartViewToggle.spec.js
+++ b/spec/javascript/pulfalight/cartViewToggle.spec.js
@@ -14,7 +14,7 @@ describe("CartViewToggle.vue", () => {
         TOGGLE_VISIBILITY: toggleVisibility
       }
     }
-    const { getByRole, container} = render(CartViewToggle, { store })
+    const { getByRole, container } = render(CartViewToggle, { store })
     const button = getByRole("button")
     await fireEvent.click(button)
     expect(toggleVisibility).toHaveBeenCalled()

--- a/spec/javascript/pulfalight/requestCart.spec.js
+++ b/spec/javascript/pulfalight/requestCart.spec.js
@@ -1,0 +1,55 @@
+import RequestCart from "components/RequestCart"
+import { cartMutations, cartActions } from "store/cart/index"
+import { render, fireEvent } from '@testing-library/vue'
+
+describe("RequestCart.vue", () => {
+  test("Submitting cart", async () => {
+    const customStore = {
+      modules: {
+        cart: {
+          state: {
+            items: [ {
+              title: "My word",
+              formParams: {
+                AeonForm: "EADRequest"
+              }
+            } ],
+            isVisible: true
+          },
+          actions: cartActions,
+          mutations: cartMutations
+        }
+      },
+    }
+
+    const { container } = render(RequestCart, {
+      store: customStore,
+      props: {
+        configuration: {}
+      }
+    })
+
+    const form = container.querySelector("form#request-cart-form")
+    expect(form.querySelector("input[name='AeonForm'][value='EADRequest']")).not.toBe(null)
+
+    const shadowForm = container.querySelector("form#shadow-form")
+    const submitMock = jest.fn()
+    shadowForm.addEventListener("submit", (event) => {
+      // can't actually submit a form in a test
+      event.preventDefault()
+      submitMock()
+    })
+
+    await fireEvent.submit(form)
+
+    // shadow form is populated
+    expect(shadowForm.querySelector("input[name='AeonForm'][value='EADRequest']")).not.toBe(null)
+
+    // shadow form was submitted
+    expect(submitMock).toHaveBeenCalled()
+
+    // cart is empty
+    const button = container.querySelector("button[type='submit']")
+    expect(button.textContent.trim()).toBe("No Items in Your Cart")
+  })
+})


### PR DESCRIPTION
Clear request cart when form is submitted to Aeon

This is achieved by copying data from form into shadow form when form is submitted, then clearing form and submitting shadow form.

Other details:
  - adjust indentation in RequestCart template for consistency
  - move `<form>` tags to contain smallest possible number of lines
  - Duplicate `<form>` into a shadow form
  - Fix use of state in RequestCart to allow test to properly mock

fixes #446
