### PR TITLE
Increase max width of header to match search results

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -3,7 +3,7 @@
     <h2>Fall Semester Announcements</h2>
     <p>We’re currently in beta for students and will be introducing faculty, advisor and staff functionality in the coming months.</p>
   </banner>
-  <library-header app-name="<%= application_name %>" app-url="<%= root_path %>">
+  <library-header app-name="<%= application_name %>" app-url="<%= root_path %>" max-width="1400">
     <div class="menu--level-1 d-none d-md-block col-md-2 col-lg-3">
       <div class="cart-view-toggle-block">
         <cart-view-toggle></cart-view-toggle>


### PR DESCRIPTION
This balances the page a bit better.

before:
![Screen Shot 2020-11-25 at 3 19 37 PM](https://user-images.githubusercontent.com/845363/100277846-dc3fbe00-2f31-11eb-8113-f0013f9c7298.png)


after:
![Screen Shot 2020-11-25 at 3 19 57 PM](https://user-images.githubusercontent.com/845363/100277854-dea21800-2f31-11eb-8f4a-7b0d61f2bb77.png)
