### PR TITLE
Widen home content a bit

### DIFF
--- a/app/assets/stylesheets/layouts/home.scss
+++ b/app/assets/stylesheets/layouts/home.scss
@@ -8,7 +8,7 @@
   text-align: center;
 
   &-text {
-    padding: 3.85rem;
+    padding: 2rem;
 
     h2 {
       margin-bottom: 1.85rem;


### PR DESCRIPTION
brings it closer to the wireframes and tidies up text wrapping in headers


before:
![Screen Shot 2020-11-25 at 3 23 15 PM](https://user-images.githubusercontent.com/845363/100278239-8ae3fe80-2f32-11eb-8aeb-64f40cc1e924.png)


after:
![Screen Shot 2020-11-25 at 3 24 59 PM](https://user-images.githubusercontent.com/845363/100278232-87507780-2f32-11eb-9a98-14b166435557.png)
