### PR TITLE
Remove recent_repositories in ASpace Client

### DIFF
--- a/app/services/aspace/client.rb
+++ b/app/services/aspace/client.rb
@@ -17,7 +17,7 @@ module Aspace
     end
 
     def ead_urls(modified_since: nil)
-      output = recent_repositories.each_with_object({}) do |repository, acc|
+      output = repositories.each_with_object({}) do |repository, acc|
         config.base_repo = repository["uri"][1..-1]
         query = { all_ids: true }
         query[:modified_since] = modified_since if modified_since
@@ -40,14 +40,6 @@ module Aspace
         code = "mss" if code == "Manuscripts"
         { result["uri"][1..-1].gsub("resources", "resource_descriptions") => code }
       end.to_a.compact.last
-    end
-
-    # We have old test repositories, we only want to import EADs from the ones
-    # migrated from our SVN by Lyrasis.
-    def recent_repositories
-      repositories.select do |repository|
-        Time.zone.parse(repository["create_time"]) > Time.zone.parse("2020-01-01")
-      end
     end
   end
 end

--- a/spec/fixtures/aspace/repositories.json
+++ b/spec/fixtures/aspace/repositories.json
@@ -1,29 +1,6 @@
 [
     {
         "agent_representation": {
-            "ref": "/agents/corporate_entities/2"
-        },
-        "create_time": "2016-06-27T14:10:41Z",
-        "created_by": "admin",
-        "display_string": "Public Policy Papers (Public Policy Papers)",
-        "is_slug_auto": true,
-        "jsonmodel_type": "repository",
-        "last_modified_by": "aa9",
-        "lock_version": 1,
-        "name": "Public Policy Papers",
-        "oai_is_disabled": false,
-        "oai_sets_available": "[]",
-        "parent_institution_name": "Princeton University Library.  Department of Rare Books and Special Collections",
-        "publish": true,
-        "repo_code": "Public Policy Papers",
-        "slug": "public_policy_papers",
-        "system_mtime": "2017-09-27T16:51:24Z",
-        "uri": "/repositories/3",
-        "url": "http://www.princeton.edu/mudd",
-        "user_mtime": "2016-06-27T20:17:08Z"
-    },
-    {
-        "agent_representation": {
             "ref": "/agents/corporate_entities/4470"
         },
         "create_time": "2020-10-05T23:13:08Z",

--- a/spec/services/aspace/client_spec.rb
+++ b/spec/services/aspace/client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Aspace::Client do
   end
 
   describe "ead_urls" do
-    it "returns EAD urls for all 2020 and later repositories, grouped by repository code" do
+    it "returns EAD urls for all repositories, grouped by repository code" do
       client = described_class.new
 
       expect(client.ead_urls).to eq(


### PR DESCRIPTION
We changed our migration method, so we no longer need this.