### PR TITLE
Lighten box around "create a research account" button

### DIFF
--- a/app/assets/stylesheets/layouts/home.scss
+++ b/app/assets/stylesheets/layouts/home.scss
@@ -54,14 +54,14 @@
       @extend .col-lg-5;
       padding-right: 0;
       div {
-        border: 1px solid black;
+        border-top: 1px solid black;
         width: 100%;
         height: 100%;
         @extend .row;
         @extend .align-items-center;
         @extend .justify-content-center;
         @extend .p-3;
-        background-color: $gray;
+        background-color: $light-gray;
         margin-top: -1px;
         a {
           @extend .btn;


### PR DESCRIPTION
And remove the dark outline

This softens the design a bit in that area. The button itself already seems a significant attention-draw and the previous weight of this design element seemed a bit incongruous.

before:
![Screen Shot 2020-11-25 at 3 34 53 PM](https://user-images.githubusercontent.com/845363/100279097-e82c7f80-2f33-11eb-9eea-292db31dd724.png)


after:
![Screen Shot 2020-11-25 at 3 33 09 PM](https://user-images.githubusercontent.com/845363/100279108-ee226080-2f33-11eb-99f1-e91a7a0e111e.png)

