### PR TITLE
Ensure search box and submit button are same height as dropdown

### DIFF
--- a/app/assets/stylesheets/modules/search.scss
+++ b/app/assets/stylesheets/modules/search.scss
@@ -2,6 +2,8 @@
 @import "variables/colors";
 @import "variables/typography";
 
+$search-box-form-height: calc(1.75em + 0.75rem + 2px);
+
 header .navbar-form .input-group .custom-select {
     width: auto;
   }
@@ -99,7 +101,7 @@ header .navbar-form .input-group .input-group-btn {
 
 .search-q.form-control,
 .search-btn {
-  height: 42px;
+  height: $search-box-form-height;
 }
 
 @media (min-width: $bp-large) {
@@ -172,7 +174,7 @@ select::-ms-expand {
 }
 
 #search_field.custom-select, #within_collection {
-  height: calc(1.75em + 0.75rem + 2px);
+  height: $search-box-form-height;
 
   @media (min-width: 575px) {
     border-top-right-radius: 0;


### PR DESCRIPTION
Also had to do this in orangelight:
https://github.com/pulibrary/orangelight/pull/1914/files

Before:
![Screen Shot 2020-11-25 at 4 42 43 PM](https://user-images.githubusercontent.com/845363/100284693-912ba800-2f3d-11eb-9ec0-7be41562fd1d.png)

after:
![Screen Shot 2020-11-25 at 4 42 50 PM](https://user-images.githubusercontent.com/845363/100284692-912ba800-2f3d-11eb-8d2c-09a789309e75.png)