### PR TITLE
Display + facet only items which themselves have online content

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -148,8 +148,8 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field "has_online_content_ssim", label: "Access", collapse: false, query: {
-      online: { label: "Online", fq: "has_online_content_ssim:true" }
+    config.add_facet_field "has_direct_online_content_ssim", label: "Access", collapse: false, query: {
+      online: { label: "Online", fq: "has_direct_online_content_ssim:true" }
     }
     config.add_facet_field "collection_sim", label: "Collection", limit: 10
     config.add_facet_field "creator_ssim", label: "Creator", limit: 10

--- a/lib/pulfalight/traject/ead2_component_config.rb
+++ b/lib/pulfalight/traject/ead2_component_config.rb
@@ -265,6 +265,9 @@ end
 to_field "has_online_content_ssim", extract_xpath(".//dao") do |_record, accumulator|
   accumulator.replace([accumulator.any?])
 end
+to_field "has_direct_online_content_ssim", extract_xpath("./did/dao") do |_record, accumulator|
+  accumulator.replace([accumulator.any?])
+end
 to_field "child_component_count_isim" do |record, accumulator|
   accumulator << Pulfalight::Ead2Indexing::NokogiriXpathExtensions.new.is_component(record.children).count
 end

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -28,7 +28,7 @@ describe "faceted searches", type: :feature, js: true do
 
     it "displays access values and is always open" do
       expect(page).to have_selector("h3.facet-field-heading:first-child button", text: "Access", visible: false)
-      expect(page).to have_selector("#facet-has_online_content_ssim.show", visible: false)
+      expect(page).to have_selector("#facet-has_direct_online_content_ssim.show", visible: false)
       expect(page).to have_selector("a.facet-select", text: "Online", visible: false)
     end
   end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -154,6 +154,8 @@ describe "EAD 2 traject indexing", type: :feature do
             )
           ]
         )
+        expect(component["has_online_content_ssim"]).to eq [true]
+        expect(component["has_direct_online_content_ssim"]).to eq [true]
       end
     end
 


### PR DESCRIPTION
Items whose children have online content shouldn't appear when you facet
to only those things with online content.