### PR TITLE
Fix mixed up date_created and created

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -265,11 +265,11 @@ class SolrDocument
   end
 
   def date_created
-    fetch("unitdate_inclusive_ssm", [])
+    fetch("normalized_date_ssm", [])
   end
 
   def created
-    fetch("normalized_date_ssm", [])
+    fetch("unitdate_inclusive_ssm", [])
   end
 
   def extent_and_dimensions

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -49,8 +49,8 @@ describe "controller requests", type: :request do
 
         expect(json_body["title"]).to eq ["Princeton University Library Collection of Western Americana Photographs"]
         expect(json_body["language"]).to eq ["English"]
-        expect(json_body["date_created"]).to eq ["1840/1998"]
-        expect(json_body["created"]).to eq ["1840-1998, bulk 1870/1915"]
+        expect(json_body["date_created"]).to eq ["1840-1998, bulk 1870/1915"]
+        expect(json_body["created"]).to eq ["1840/1998"]
         expect(json_body["extent"]).to eq ["144 boxes", "123 linear feet"]
         expect(json_body["heldBy"]).to eq ["Firestone Library"]
         expect(json_body["memberOf"]).to be_nil


### PR DESCRIPTION
Was causing a parsing error in Figgy. Date_created should be the
human-readable view of the date, created is an actual date string if it
exists.