### PR TITLE
Table of contents opens direct children when clicked on.

### DIFF
--- a/app/services/table_of_contents_builder.rb
+++ b/app/services/table_of_contents_builder.rb
@@ -43,13 +43,21 @@ class TableOfContentsBuilder
     document.fetch("component_level_isim", ["0"]).first.to_i
   end
 
+  def component_ancestry
+    document.fetch("parent_ssm", [])
+  end
+
   def content(component, level: 0, full: false)
     {
       id: component["id"],
       text: text(component),
       has_children: component["components"].present?,
-      state: { opened: @expanded || (full && level < component_level + 1) } # This applies to every node in the tree
+      state: { opened: @expanded || (full && expand?(component, level)) } # This applies to every node in the tree
     }
+  end
+
+  def expand?(component, current_level)
+    component["id"] == document["id"] || (component_ancestry.include?(component["id"]) && current_level < component_level + 1)
   end
 
   def text(component)

--- a/app/services/table_of_contents_builder.rb
+++ b/app/services/table_of_contents_builder.rb
@@ -39,12 +39,6 @@ class TableOfContentsBuilder
     document.fetch("parent_ssm", [document.id]).first
   end
 
-  def document_children_ids
-    document.fetch("components", []).map do |component|
-      component["id"]
-    end
-  end
-
   def content(component)
     {
       id: component["id"],

--- a/spec/services/table_of_contents_builder_spec.rb
+++ b/spec/services/table_of_contents_builder_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe TableOfContentsBuilder do
       expect(selected_component["id"]).to eq "MC221_c0004"
       expect(selected_component["text"]).to eq "National War College, 1949 November 1"
       expect(selected_component["children"]).to be_nil
+      # Ensure that the ToC node you request is opened.
+      expect(selected_component["state"]["opened"]).to eq true
+    end
+  end
+
+  context "when requesting toc data for a full tree, with a middle level component selected" do
+    it "generates a full JSON document, but only opens the correct level" do
+      document = SolrDocument.find("MC221_c0001")
+      output = described_class.build(document)
+      toc_hash = JSON.parse(output)
+
+      # Ancestor series component
+      series_level_components = toc_hash
+      series_level_component = series_level_components[0]
+      expect(series_level_component["state"]["opened"]).to eq true
+      expect(series_level_component["children"][0]["state"]["opened"]).to eq false
     end
   end
 
@@ -50,6 +66,9 @@ RSpec.describe TableOfContentsBuilder do
       child_component = toc_hash[1]
       expect(child_component["id"]).to eq "MC221_c0003"
       expect(child_component["text"]).to eq "Speeches, 1949 November-1960 February"
+      # Ensure it doesn't load it as opened when requesting a single node - this
+      # happens when clicking the "arrow"
+      expect(child_component["state"]["opened"]).to eq false
       # No deeply nested child components
       expect(child_component["children"]).to be_truthy
     end

--- a/spec/services/table_of_contents_builder_spec.rb
+++ b/spec/services/table_of_contents_builder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TableOfContentsBuilder do
       # Ancestor series component
       series_level_components = toc_hash
       series_level_component = series_level_components[0]
+      expect(series_level_components[1]["state"]["opened"]).to eq false
       expect(series_level_component["children"].count).to eq 52
       expect(series_level_component["id"]).to eq "MC221_c0001"
       expect(series_level_component["children"]).not_to be_empty

--- a/spec/services/table_of_contents_builder_spec.rb
+++ b/spec/services/table_of_contents_builder_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe TableOfContentsBuilder do
 
       # Return all child documents
       expect(toc_hash.count).to eq 52
+      expect(toc_hash[0]["state"]["opened"]).to eq false
 
       child_component = toc_hash[1]
       expect(child_component["id"]).to eq "MC221_c0003"


### PR DESCRIPTION
Closes #576

ToC looks like this when navigating directly to a component now, expanding its direct children:

![Screen Shot 2021-02-02 at 1 57 26 PM](https://user-images.githubusercontent.com/2806645/106668053-a1c05600-655e-11eb-8acd-e6bd51c2ac24.png)
