### PR TITLE
Fix Pulfalight Figgy Viewer

### DIFF
--- a/app/javascript/pulfalight/query_figgy.es6
+++ b/app/javascript/pulfalight/query_figgy.es6
@@ -62,7 +62,7 @@ export default class {
 
   component_id() {
     let doc_aspace_component_id = document.getElementById('document').getElementsByTagName('div')[0]
-    let component_id = doc_aspace_component_id.getAttribute('id').replace('doc_aspace_', '')
+    let component_id = doc_aspace_component_id.getAttribute('id').replace('doc_', '')
     let underscorePosition = component_id.indexOf('_')
     component_id = this.uppercaseChar(component_id,underscorePosition) + component_id.slice(underscorePosition)
     return component_id;

--- a/spec/javascript/pulfalight/query_figgy.spec.js
+++ b/spec/javascript/pulfalight/query_figgy.spec.js
@@ -61,7 +61,7 @@ describe('QueryFiggy', function() {
   })
 
   test("component_id() Capitalizes alphabetic characters before the underscore", () => {
-    document.body.innerHTML = '<div id="document" class="document blacklight-file" itemscope="" itemtype="http://schema.org/Thing"><div id="doc_aspace_c1491_c4"></div></div>'
+    document.body.innerHTML = '<div id="document" class="document blacklight-file" itemscope="" itemtype="http://schema.org/Thing"><div id="doc_c1491_c4"></div></div>'
     const query = new QueryFiggy
     expect(query.component_id(component_id)).toEqual("C1491_c4")
   })


### PR DESCRIPTION
Closes #666

It was broken because we don't have `aspace_` in our component IDs anymore.