### PR TITLE
Fix deprecation warning

### DIFF
--- a/spec/controllers/research_help_controller_spec.rb
+++ b/spec/controllers/research_help_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ResearchHelpController, type: :controller do
     it "routes to the help page" do
       get :research_help
 
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 end


### PR DESCRIPTION
Fixes deprecation warning:

```
DEPRECATION WARNING: The success? predicate is deprecated and will be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers. (called from block (3 levels) in <top (required)> at /Users/bess/projects/pulfalight/spec/controllers/research_help_controller_spec.rb:9)
```