### PR TITLE
Group by a unique identifier for requests.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Metrics/ClassLength:
     - 'app/models/solr_document.rb'
     - 'app/controllers/catalog_controller.rb'
     - 'app/services/aspace_fixture_generator.rb'
+    - 'app/values/aeon_request.rb'
 Metrics/MethodLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'

--- a/app/values/aeon_request.rb
+++ b/app/values/aeon_request.rb
@@ -39,8 +39,18 @@ class AeonRequest
       "ItemInfo3_#{request_id}": folder,
       "ItemInfo4_#{request_id}": container_profile,
       "ItemInfo5_#{request_id}": url,
-      "Location_#{request_id}": container_locations
+      "Location_#{request_id}": container_locations,
+      "GroupingField_#{request_id}": grouping_identifier
     }.merge(grouping_options)
+  end
+
+  # Group all box components in the same EAD together.
+  def grouping_identifier
+    "#{ead_id}-#{box}"
+  end
+
+  def ead_id
+    Array.wrap(solr_document.fetch("ead_ssi", [])).first
   end
 
   def container_locations
@@ -106,7 +116,7 @@ class AeonRequest
 
   def grouping_options
     {
-      GroupingIdentifier: "ItemVolume",
+      GroupingIdentifier: "GroupingField",
       GroupingOption_ReferenceNumber: "Concatenate",
       GroupingOption_ItemNumber: "Concatenate",
       GroupingOption_ItemDate: "FirstValue",

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Arclight::SolrDocument do
       expect(request.form_attributes[:Site]).to eq "RBSC"
       expect(request.form_attributes[:Location]).to eq "mss"
       expect(request.form_attributes[:ItemTitle]).to eq "Diary"
-      expect(request.form_attributes[:GroupingIdentifier]).to eq "ItemVolume"
+      expect(request.form_attributes[:GroupingIdentifier]).to eq "GroupingField"
       expect(request.form_attributes[:GroupingOption_ReferenceNumber]).to eq "Concatenate"
       expect(request.form_attributes[:GroupingOption_ItemNumber]).to eq "Concatenate"
       expect(request.form_attributes[:GroupingOption_ItemDate]).to eq "FirstValue"
@@ -268,6 +268,8 @@ RSpec.describe Arclight::SolrDocument do
       # https://findingaids.princeton.edu/collections/C1588/c2
       expect(request.form_attributes[:Request]).not_to be_blank
       request_id = request.form_attributes[:Request]
+      # Ensure the box/collection unitid are in as a grouping identifier.
+      expect(request.form_attributes[:"GroupingField_#{request_id}"]).to eq "C1588test-Box B-001180"
       expect(request.form_attributes[:"ItemSubTitle_#{request_id}"]).to eq "Diaries / Diary"
       expect(request.form_attributes[:"ItemTitle_#{request_id}"]).to eq "Walter Dundas Bathurst Papers"
       expect(request.form_attributes[:"ItemAuthor_#{request_id}"]).to eq "Bathurst, Walter Dundas, 1859-1940"


### PR DESCRIPTION
Adding a grouping identifier for Aeon which includes the EADID ensures
that only the same box merges into the same call slip.

Closes #696

Special thanks to https://blog.rockarch.org/technical-overview-of-ead-requesting-with-aeon and @helrond (which is funny, because PULFA2 is referenced there. :joy:)