### PR TITLE
Display collection level storage note on component pages

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -346,6 +346,7 @@ class CatalogController < ApplicationController
     config.add_component_field "parent_access_restrict_ssm", label: "Access Restrictions"
     config.add_component_field "acqinfo_ssm", label: "Acquisition", helper_method: :paragraph_separator
     config.add_component_field "prefercite_ssm", label: "Credit this material", helper_method: :paragraph_separator
+    config.add_component_field "storage_notes", label: "Storage Note", accessor: :component_storage_notes, helper_method: :paragraph_separator
 
     config.add_component_field "topics_ssim", label: "Topics", link_to_facet: true, separator_options: {
       words_connector: "<br/>",

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -260,6 +260,10 @@ class SolrDocument
     StorageNotes.for(fetch("physloc_ssm", [])).to_a.concat(fetch("location_note_ssm", [])).map(&:html_safe)
   end
 
+  def component_storage_notes
+    StorageNotes.for(fetch("physloc_code_ssm", [])).to_a.concat(fetch("location_note_ssm", [])).map(&:html_safe)
+  end
+
   def language
     fetch("language_ssm", []).map(&:strip)
   end

--- a/app/services/storage_notes.rb
+++ b/app/services/storage_notes.rb
@@ -15,7 +15,7 @@ class StorageNotes
   end
 
   def to_a
-    Array.wrap(config[location_code] || [])
+    Array.wrap(config[location_code&.downcase] || [])
   end
 
   class Combined

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -27,6 +27,12 @@ describe "viewing catalog records", type: :feature, js: true do
       expect(page).to have_field "ask_a_question_form_context", visible: false, type: :hidden, with: "http://www.example.com/catalog/MC221_c0059"
       expect(page).to have_field "ask_a_question_form_title", visible: false, type: :hidden, with: "Harold B. Hoskins Papers, 1822-1982"
     end
+    it "has a collection level storage note" do
+      visit "catalog/MC221_c0059"
+      expect(page).to have_content("Storage Note:")
+      expect(page).to have_content("Mudd Library collections are unavailable until further notice due to a renovation.")
+      expect(page).to have_link("our webpage", href: "https://library.princeton.edu/special-collections/policies/access-mudd-library-during-renovation")
+    end
   end
   context "when viewing a component which can be requested from Aeon" do
     it "renders a request button which opens a request cart form" do


### PR DESCRIPTION
Connected to #701 

![Screen Shot 2021-03-02 at 4 35 53 PM](https://user-images.githubusercontent.com/65608/109718569-82284780-7b75-11eb-841c-346e7fbbad0b.png)
