### PR TITLE
Run feature specs in browser by setting an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To stop solr and database services: `rake pulfalight:server:stop` or `lando stop
 
 #### Run tests
 `bundle exec rspec`
+To watch feature tests run in a browser, make sure chrome is installed and run: `RUN_IN_BROWSER=true rspec spec`
 
 #### Start development server
 - `rails s`

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -4,11 +4,13 @@ require "capybara/rspec"
 require "selenium-webdriver"
 
 Capybara.register_driver(:selenium) do |app|
+  capability_args = %w[disable-gpu disable-setuid-sandbox]
+  capability_args << "headless" unless ENV['RUN_IN_BROWSER'] == 'true'
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu disable-setuid-sandbox] }
+    chromeOptions: { args: capability_args }
   )
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << "--headless"
+  browser_options.args << "--headless" unless ENV['RUN_IN_BROWSER'] == 'true'
   browser_options.args << "--disable-gpu"
 
   http_client = Selenium::WebDriver::Remote::Http::Default.new


### PR DESCRIPTION
To turn off headless mode, run specs with RUN_IN_BROWSER=true set

Fixes #699 
