### PR TITLE
XML Display for Collections

### DIFF
--- a/app/jobs/aspace_index_job.rb
+++ b/app/jobs/aspace_index_job.rb
@@ -43,7 +43,7 @@ class AspaceIndexJob < ApplicationJob
   end
 
   def perform(resource_descriptions_uri:, repository_id: nil)
-    ead_content = aspace_client.get("#{resource_descriptions_uri}.xml", query: { include_daos: true, include_unpublished: false }, timeout: 1200).body.force_encoding("UTF-8")
+    ead_content = aspace_client.get_resource_description_xml(resource_descriptions_uri: resource_descriptions_uri, cached: false)
     xml_documents = Nokogiri::XML.parse(ead_content)
     xml_documents.remove_namespaces!
     return delete_document(xml_documents) if xml_documents.children[0]["audience"] == "internal"

--- a/app/jobs/index_job.rb
+++ b/app/jobs/index_job.rb
@@ -39,7 +39,7 @@ class IndexJob < ApplicationJob
   # @return [Array<Nokogiri::XML::Document>]
   def xml_documents
     @xml_documents ||= @file_paths.map do |file_path|
-      doc_string = File.open(file_path)
+      doc_string = File.read(file_path).gsub("aspace_", "")
       document = Nokogiri::XML.parse(doc_string)
       document.remove_namespaces!
       document

--- a/app/models/pulfalight/document/xml_export.rb
+++ b/app/models/pulfalight/document/xml_export.rb
@@ -5,7 +5,10 @@ module Pulfalight::Document::XMLExport
   end
 
   def export_as_xml
-    client.get_xml(eadid: eadid)
+    content = client.get_xml(eadid: eadid)
+    return content if collection?
+    document = Nokogiri::XML.parse(content)
+    document.xpath("//*[@id='#{id}']")[0].to_xml
   end
 
   def client

--- a/app/models/pulfalight/document/xml_export.rb
+++ b/app/models/pulfalight/document/xml_export.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Pulfalight::Document::XMLExport
+  def self.extended(document)
+    document.will_export_as(:xml)
+  end
+
+  def export_as_xml
+    client.get_xml(eadid: eadid)
+  end
+
+  def client
+    Aspace::Client.new
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -17,7 +17,8 @@ class SolrDocument
   # single valued. See Blacklight::Document::SemanticFields#field_semantics
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
-  use_extension(Blacklight::Document::DublinCore)
+  # use_extension(Blacklight::Document::DublinCore)
+  SolrDocument.use_extension(Pulfalight::Document::XMLExport)
 
   COLLECTION_LEVEL = "collection"
   ROOT_COMPONENT_LEVEL = 1

--- a/app/models/xml_cache.rb
+++ b/app/models/xml_cache.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class XmlCache < ApplicationRecord
+end

--- a/app/services/aspace/client.rb
+++ b/app/services/aspace/client.rb
@@ -52,11 +52,13 @@ module Aspace
     def get_resource_description_xml(resource_descriptions_uri:, cached: true)
       cache = XmlCache.find_or_initialize_by(resource_descriptions_uri: resource_descriptions_uri)
       return cache.content if cache.content.present? && cached
-      get("#{resource_descriptions_uri}.xml", query: { include_daos: true, include_unpublished: false }, timeout: 1200).body.force_encoding("UTF-8").tap do |content|
-        cache.content = content
-        cache.ead_id = Nokogiri::XML.parse(content).remove_namespaces!.xpath("//eadid")[0].text
-        cache.save!
-      end
+      content = get("#{resource_descriptions_uri}.xml", query: { include_daos: true, include_unpublished: false }, timeout: 1200).body.force_encoding("UTF-8")
+      # Strip prefix from EAD.
+      content = content.gsub("aspace_", "")
+      cache.content = content
+      cache.ead_id = Nokogiri::XML.parse(content).remove_namespaces!.xpath("//eadid")[0].text
+      cache.save!
+      content
     end
   end
 end

--- a/app/services/aspace/client.rb
+++ b/app/services/aspace/client.rb
@@ -41,5 +41,14 @@ module Aspace
         { result["uri"][1..-1].gsub("resources", "resource_descriptions") => code }
       end.to_a.compact.last
     end
+
+    def get_xml(eadid:, cached: true)
+      url = ead_url_for_eadid(eadid: eadid).keys.first
+      get_resource_description_xml(resource_descriptions_uri: url, cached: cached)
+    end
+
+    def get_resource_description_xml(resource_descriptions_uri:, cached: true)
+      get("#{resource_descriptions_uri}.xml", query: { include_daos: true, include_unpublished: false }, timeout: 1200).body.force_encoding("UTF-8")
+    end
   end
 end

--- a/db/migrate/20210405214959_create_xml_caches.rb
+++ b/db/migrate/20210405214959_create_xml_caches.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class CreateXmlCaches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :xml_caches do |t|
+      t.string :resource_descriptions_uri
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210405220028_add_ead_id_to_xml_cache.rb
+++ b/db/migrate/20210405220028_add_ead_id_to_xml_cache.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddEadIdToXmlCache < ActiveRecord::Migration[5.2]
+  def change
+    add_column :xml_caches, :ead_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_29_231133) do
+ActiveRecord::Schema.define(version: 2021_04_05_220028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,14 @@ ActiveRecord::Schema.define(version: 2020_10_29_231133) do
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid"
+  end
+
+  create_table "xml_caches", force: :cascade do |t|
+    t.string "resource_descriptions_uri"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ead_id"
   end
 
 end

--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -360,9 +360,9 @@ end
 sanitizer = Rails::Html::SafeListSanitizer.new
 ["processing", "conservation"].each do |processinfo_type|
   selector = if processinfo_type == "processing"
-               "processinfo[@id!='aspace_conservation']"
+               "processinfo[@id!='conservation']"
              else
-               "processinfo[@id='aspace_conservation']"
+               "processinfo[@id='conservation']"
              end
   to_field "processinfo_#{processinfo_type}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false) do |_record, accumulator|
     accumulator.map! do |element|

--- a/spec/jobs/aspace_index_job_spec.rb
+++ b/spec/jobs/aspace_index_job_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe AspaceIndexJob do
         items = connection.get("select", params: { q: "id:C1588test" })
         expect(items["response"]["numFound"]).to eq 1
         expect(items["response"]["docs"].first["repository_ssm"]).to eq ["Manuscripts Division"]
+
+        cache = XmlCache.first
+        expect(cache.ead_id).to eq "C1588test"
+        expect(cache.resource_descriptions_uri).to eq "repositories/13/resources/5396"
       end
     end
     context "when given an EAD which is suddenly internal" do

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -17,8 +17,8 @@ describe "controller requests", type: :request do
       it "returns the full finding aid from ASpace" do
         stub_aspace_login
         stub_aspace_repositories
-        stub_aspace_resource_ids(repository_id: "13", resource_ids: ["WC064"])
-        stub_aspace_ead(resource_descriptions_uri: "repositories/13/resource_descriptions/WC064", ead: "generated/mss/WC064.processed.EAD.xml")
+        search_stub = stub_search(repository_id: "13", resource_ids: ["WC064"]).last
+        ead_stub = stub_aspace_ead(resource_descriptions_uri: "repositories/13/resource_descriptions/WC064", ead: "generated/mss/WC064.processed.EAD.xml")
 
         get "/catalog/WC064.xml"
 
@@ -26,6 +26,11 @@ describe "controller requests", type: :request do
         doc = Nokogiri::XML.parse(response.body)
         doc.remove_namespaces!
         expect(doc.xpath("//eadid").first.text).to eq "WC064"
+
+        # Ensure caching is working
+        get "/catalog/WC064.xml"
+        expect(ead_stub).to have_been_requested.once
+        expect(search_stub).to have_been_requested.once
       end
     end
   end

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -12,6 +12,24 @@ describe "controller requests", type: :request do
     end
   end
 
+  describe "/catalog/:id XML" do
+    context "for a collection" do
+      it "returns the full finding aid from ASpace" do
+        stub_aspace_login
+        stub_aspace_repositories
+        stub_aspace_resource_ids(repository_id: "13", resource_ids: ["WC064"])
+        stub_aspace_ead(resource_descriptions_uri: "repositories/13/resource_descriptions/WC064", ead: "generated/mss/WC064.processed.EAD.xml")
+
+        get "/catalog/WC064.xml"
+
+        expect(response).to be_successful
+        doc = Nokogiri::XML.parse(response.body)
+        doc.remove_namespaces!
+        expect(doc.xpath("//eadid").first.text).to eq "WC064"
+      end
+    end
+  end
+
   describe "/catalog/:id JSON" do
     context "for a component" do
       it "renders sufficient JSON for Figgy to use" do

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -34,6 +34,25 @@ describe "controller requests", type: :request do
         expect(search_stub).to have_been_requested.once
       end
     end
+    context "for a component" do
+      it "shows the component XML" do
+        stub_aspace_login
+        stub_aspace_repositories
+        search_stub = stub_search(repository_id: "13", resource_ids: ["WC064"]).last
+        ead_stub = stub_aspace_ead(resource_descriptions_uri: "repositories/13/resource_descriptions/WC064", ead: "generated/mss/WC064.processed.EAD.xml")
+
+        get "/catalog/WC064_c1.xml"
+
+        expect(response).to be_successful
+        doc = Nokogiri::XML.parse(response.body)
+        expect(doc.children[0]["id"]).to eq "WC064_c1"
+
+        # Ensure caching is working
+        get "/catalog/WC064_c1.xml"
+        expect(ead_stub).to have_been_requested.once
+        expect(search_stub).to have_been_requested.once
+      end
+    end
   end
 
   describe "/catalog/:id JSON" do

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -26,6 +26,7 @@ describe "controller requests", type: :request do
         doc = Nokogiri::XML.parse(response.body)
         doc.remove_namespaces!
         expect(doc.xpath("//eadid").first.text).to eq "WC064"
+        expect(doc.xpath("//c").first["id"]).to eq "WC064_c1"
 
         # Ensure caching is working
         get "/catalog/WC064.xml"

--- a/spec/support/archivespace_stub.rb
+++ b/spec/support/archivespace_stub.rb
@@ -23,8 +23,8 @@ module AspaceStubbing
   end
 
   def stub_search(repository_id:, resource_ids:)
-    resource_ids.each do |resource_id|
-      all_repository_ids.each do |curr_repo_id|
+    resource_ids.flat_map do |resource_id|
+      all_repository_ids.map do |curr_repo_id|
         if curr_repo_id == repository_id
           stub_request(:get, "https://aspace.test.org/staff/api/repositories/#{repository_id}/search?fields%5B%5D=identifier&fields%5B%5D=uri&page=1&q=identifier:#{resource_id}&type%5B%5D=resource")
             .to_return(status: 200, body: resource_response(repository_id, resource_id).to_json, headers: { "Content-Type": "application/json" })


### PR DESCRIPTION
Closes #107

This adds an XML caching layer in ActiveRecord. It's the simplest low level cache store we have around and by utilizing one row per ead_id we don't have to worry about it getting too big or having a bunch of stale content.