### PR TITLE
Add a temporary stopgap measure for UV display.

### DIFF
--- a/app/assets/stylesheets/layouts/catalog_show.scss
+++ b/app/assets/stylesheets/layouts/catalog_show.scss
@@ -24,6 +24,7 @@
   .uv__overlay {
     width: 100%;
     height: 600px;
+    min-width: 805px;
     iframe {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
This just makes the UV scroll to the right if there's not enough space
to be full screen. It doesn't look great, but researchers can access the
material.