### PR TITLE
Update capistrano-passenger.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (1.6.0)
       capistrano (~> 3.1)
-    capistrano-passenger (0.2.0)
+    capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
@@ -572,4 +572,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.6
+   2.2.16


### PR DESCRIPTION
Passenger updated on staging/production at some point, which changed the
format of passenger -v. The new version of capistrano-passenger fixes
the restart.