### PR TITLE
Do not raise exceptions for unmatched pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
     return key if key
     "guest_" + guest_user_unique_suffix
   end
+
+  def route_not_found
+    render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -484,6 +484,10 @@ class CatalogController < ApplicationController
     config.view.compact.partials = %i[arclight_index_compact]
   end
 
+  rescue_from Blacklight::Exceptions::RecordNotFound do
+    render "record_not_found", status: :not_found
+  end
+
   private
 
   def document_expanded?

--- a/app/views/catalog/record_not_found.html.erb
+++ b/app/views/catalog/record_not_found.html.erb
@@ -1,0 +1,4 @@
+<div class='record-not-found'>
+  <h1>The page you were looking for doesn't exist.</h1>
+  <p>You may have mistyped the address or provided an invalid Object ID (<%= params[:id] %>)</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,4 +61,6 @@ Rails.application.routes.draw do
 
   get "/pacscl/production", to: "partner_exports#pacscl"
   get "/pacscl/production/:id", to: "partner_exports#pacscl_xml", as: :pacscl_xml
+
+  match "*unmatched", to: "application#route_not_found", via: :all
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Errors", type: :request do
-  describe ":not found" do
+  describe "unmatched routes" do
     before(:all) { get "/nonexistent_resource" }
 
     it "has an http status of 404" do
@@ -12,6 +12,18 @@ RSpec.describe "Errors", type: :request do
 
     it "redirects to the custom not_found error page" do
       expect(response.body).to include("The page you were looking for doesn't exist.")
+    end
+  end
+
+  # Blacklight::Exceptions::RecordNotFound
+  describe "record not found" do
+    it "renders a 404 page" do
+      params = { id: "unknown_work" }
+      get "/catalog/#{params[:id]}"
+
+      expect(response.status).to eq(404)
+      expect(response.body).to include("The page you were looking for doesn't exist.")
+      expect(response.body).to include("unknown_work")
     end
   end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Errors", type: :request do
+  describe ":not found" do
+    before(:all) { get "/nonexistent_resource" }
+
+    it "has an http status of 404" do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "redirects to the custom not_found error page" do
+      expect(response.body).to include("The page you were looking for doesn't exist.")
+    end
+  end
+end


### PR DESCRIPTION
* Render a static 404 page for an unmatched route
* Render a 404 and a resource_not_found page for unmatched resource ids

Fixes #705 