### PR TITLE
Bump hosted-git-info from 2.8.8 to 2.8.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - pulfalight-{{ checksum "Gemfile.lock" }}
+            - pulfalight-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
       - run: sudo apt update && sudo apt install postgresql-client
       - run:
           name: Update bundler
@@ -39,7 +39,7 @@ jobs:
           name: Install dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
-          key: pulfalight-{{ checksum "Gemfile.lock" }}
+          key: pulfalight-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
           paths:
             - ./vendor/bundle
       - run:
@@ -76,7 +76,7 @@ jobs:
           name: Install dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
-          key: pulfalight-{{ checksum "Gemfile.lock" }}
+          key: pulfalight-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
           paths:
             - ./vendor/bundle
 
@@ -134,7 +134,7 @@ jobs:
           name: Install dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
-          key: pulfalight-{{ checksum "Gemfile.lock" }}
+          key: pulfalight-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
           paths:
             - ./vendor/bundle
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4498,9 +4498,9 @@ homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hpack.js@^2.1.6:
   version "2.1.6"


### PR DESCRIPTION
Ensures that the changes from https://github.com/pulibrary/pulfalight/pull/820 are ported with an updated CircleCI configuration (otherwise the caching for the CI environment breaks the tests).