### PR TITLE
Use a released version of archivesspace-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :development, :test do
   gem "database_cleaner"
 end
 
-gem "archivesspace-client", github: "pulibrary/archivesspace-client", branch: "fix_login"
+gem "archivesspace-client"
 gem "arclight", git: "https://github.com/projectblacklight/arclight.git"
 gem "blacklight_range_limit", "~> 7.1"
 gem "bootstrap", ">= 4.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,16 +10,6 @@ GIT
       traject (~> 3.0)
       traject_plus (~> 1.2)
 
-GIT
-  remote: https://github.com/pulibrary/archivesspace-client.git
-  revision: 808b08d66b71025a331f0ba67d84b2b28be5a4ae
-  branch: fix_login
-  specs:
-    archivesspace-client (0.1.5)
-      httparty (= 0.14.0)
-      json (>= 2.0.3)
-      nokogiri (>= 1.6.8.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -68,6 +58,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    archivesspace-client (0.1.8)
+      httparty (~> 0.14)
+      json (~> 2.0)
+      nokogiri (~> 1.10)
     arel (9.0.0)
     ast (2.4.1)
     autoprefixer-rails (9.7.4)
@@ -193,7 +187,8 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
-    httparty (0.14.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.8.9)
@@ -240,6 +235,9 @@ GEM
       mimemagic (~> 0.3.2)
     maruku (0.7.3)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
@@ -519,7 +517,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  archivesspace-client!
+  archivesspace-client
   arclight!
   axe-core-rspec
   bixby (~> 3.0)
@@ -573,4 +571,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.16
+   2.2.21


### PR DESCRIPTION
For awhile we had to maintain a locally forked copy of the
archivesspace-client gem, but the fix we made locally has since been
incorporated upstream.

Note this is the same fix we made for abid: https://github.com/pulibrary/abid/issues/15

Fixes #839 