### PR TITLE
Handles invalid date ragne exception gracefully

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -489,6 +489,10 @@ class CatalogController < ApplicationController
     render "record_not_found", status: :not_found
   end
 
+  rescue_from BlacklightRangeLimit::InvalidRange do
+    redirect_to '/', flash: { error: 'The start year must be before the end year.' }
+  end
+
   private
 
   def document_expanded?


### PR DESCRIPTION
Fixes #564 

As indicated in [the issue](https://github.com/pulibrary/pulfalight/issues/564#issuecomment-856192038) the fix uses the same code as we do in Orangelight.