### PR TITLE
Improve Traject performance.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,3 +75,6 @@ Rails/OutputSafety:
 Rails/SkipsModelValidations:
   Exclude:
     - 'app/services/aspace/indexer.rb'
+Lint/SuppressedException:
+  Exclude:
+    - 'lib/tasks/performance.rake'

--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,11 @@ gem "bootsnap", ">= 1.1.0", require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem "benchmark-ips"
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 5.0"
+  gem "ruby-prof"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     backport (1.1.2)
     bcrypt (3.1.13)
+    benchmark-ips (2.9.1)
     bindex (0.5.0)
     bixby (3.0.1)
       rubocop (= 0.85.1)
@@ -367,6 +368,7 @@ GEM
       rubocop (>= 0.82.0)
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
+    ruby-prof (1.4.3)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubytree (1.0.0)
@@ -520,6 +522,7 @@ DEPENDENCIES
   archivesspace-client
   arclight!
   axe-core-rspec
+  benchmark-ips
   bixby (~> 3.0)
   blacklight_range_limit (~> 7.1)
   bootsnap (>= 1.1.0)
@@ -551,6 +554,7 @@ DEPENDENCIES
   rails-controller-testing
   rsolr (>= 1.0, < 3)
   rspec-rails (~> 5.0)
+  ruby-prof
   rubytree
   rubyzip (>= 1.3.0)
   sass-rails (~> 5.0)
@@ -571,4 +575,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.21
+   2.2.25

--- a/lib/pulfalight/traject/ead2_component_config.rb
+++ b/lib/pulfalight/traject/ead2_component_config.rb
@@ -596,8 +596,11 @@ to_field "genreform_ssim", extract_xpath("./controlaccess/genreform")
 to_field "components" do |record, accumulator, context|
   child_components = record.xpath("./*[is_component(.)]", NokogiriXpathExtensions.new)
   child_components.each do |child_component|
-    root_context = settings[:root]
-    component_indexer = build_component_indexer(root_context, context)
+    component_indexer.settings do
+      provide :parent, context
+      provide :root, context.settings[:root]
+      provide :repository, context.settings[:repository]
+    end
     output = component_indexer.map_record(child_component)
     accumulator << output
   end

--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -413,13 +413,17 @@ end
 
 to_field "components" do |record, accumulator, context|
   xpath = if record.is_a?(Nokogiri::XML::Document)
-            "/ead/archdesc/dsc/*[is_component(.)][@level != 'otherlevel']"
+            "/ead/archdesc/dsc/c[@level != 'otherlevel']"
           else
-            "./*[is_component(.)][@level != 'otherlevel']"
+            "./c[@level != 'otherlevel']"
           end
   child_components = record.xpath(xpath, Pulfalight::Ead2Indexing::NokogiriXpathExtensions.new)
   child_components.each do |child_component|
-    component_indexer = build_component_indexer(context, context)
+    component_indexer.settings do
+      provide :parent, context
+      provide :root, context
+      provide :repository, context.settings[:repository]
+    end
     output = component_indexer.map_record(child_component)
     accumulator << output
   end

--- a/lib/pulfalight/traject/ead2_indexing.rb
+++ b/lib/pulfalight/traject/ead2_indexing.rb
@@ -34,8 +34,8 @@ module Pulfalight
 
     def configure_before
       settings do
-        provide "reader_class_name", "Arclight::Traject::NokogiriNamespacelessReader"
-        provide "solr_writer.commit_on_close", "true"
+        provide "reader_class_name", "Traject::NokogiriReader"
+        provide "solr_writer.commit_on_close", "false"
         provide "repository", ENV["REPOSITORY_ID"]
         provide "logger", Logger.new($stderr)
       end
@@ -57,12 +57,14 @@ module Pulfalight
       end
     end
 
-    def build_component_indexer(root_context, parent = nil)
-      config_file_path = Rails.root.join("lib", "pulfalight", "traject", "ead2_component_config.rb")
-      indexer_settings = { parent: parent, repository: settings["repository"], root: root_context }
-      Traject::Indexer::NokogiriIndexer.new(indexer_settings).tap do |i|
-        i.load_config_file(config_file_path)
-      end
+    def component_indexer
+      @component_indexer ||=
+        begin
+          config_file_path = Rails.root.join("lib", "pulfalight", "traject", "ead2_component_config.rb")
+          Traject::Indexer::NokogiriIndexer.new.tap do |i|
+            i.load_config_file(config_file_path)
+          end
+        end
     end
 
     # Returns if DAO should be indexed.

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :performance do
+  require "ruby-prof"
+  task reindex_profile: :environment do
+    aspace_client = Aspace::Client.new
+    # Force cache
+    aspace_client.get_resource_description_xml(resource_descriptions_uri: "repositories/3/resource_descriptions/1777", cached: false)
+    result = RubyProf.profile do
+      AspaceIndexJob.perform_now(resource_descriptions_uri: "repositories/3/resource_descriptions/1777", repository_id: "publicpolicy", soft: true)
+    end
+    printer = RubyProf::CallStackPrinter.new(result)
+    printer.print(File.open("tmp/output.html", "w"))
+  end
+  task reindex_benchmark: :environment do
+    require "benchmark/ips"
+    Benchmark.ips do |x|
+      x.report("traject index") do
+        AspaceIndexJob.perform_now(resource_descriptions_uri: "repositories/3/resource_descriptions/1777", repository_id: "publicpolicy", soft: true)
+      end
+    end
+  end
+rescue LoadError
+end


### PR DESCRIPTION
Avoiding re-creating the ComponentIndexer for every component speeds up
indexing by at least 5x.