### PR TITLE
Address a few deprecation warnings

### DIFF
--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -5,7 +5,7 @@
   <div class="col col-no-left-padding col-no-right-padding">
     <div class="d-flex justify-content-between">
       <h3 class="col col-no-left-padding">
-        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+        <%= link_to_document document, document_show_link_field(document).to_s, counter: document_counter %>
       </h3>
       <%= render_index_doc_actions document %>
     </div>

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -7,7 +7,7 @@
   <div class="col col-no-left-padding d-flex flex-wrap">
     <div class="documentHeader my-w-75 w-md-100 order-0" data-document-id="<%= document.id %>">
       <h3 class="index_title document-title-heading">
-        <%= link_to_document document, document_show_link_field(document), counter: counter %>
+        <%= link_to_document document, document_show_link_field(document).to_s, counter: counter %>
 
 
         <%= content_tag('div', class: 'al-document-extent badge') do %>

--- a/app/views/catalog/_group_header_default.html.erb
+++ b/app/views/catalog/_group_header_default.html.erb
@@ -6,7 +6,7 @@
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>
-      <h3><%= link_to_document document, document_show_link_field(document) %></h3>
+      <h3><%= link_to_document document, document_show_link_field(document).to_s %></h3>
       <%= content_tag('div', class: 'al-document-extent badge') do %>
         <%= document.eadid %>
       <% end if document.collection? %>


### PR DESCRIPTION
DEPRECATION WARNING: passing a Symbol to link_to_document is deprecated and
will be removed in Blacklight 8