### PR TITLE
Don't mount the app root in Lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,17 +4,20 @@ services:
     type: solr:8.4
     portforward: true
     core: pulfalight-core-test
+    app_mount: false
     config:
       dir: "solr/conf"
   pulfalight_development_solr:
     type: solr:8.4
     portforward: true
     core: pulfalight-core-dev
+    app_mount: false
     config:
       dir: "solr/conf"
   pulfalight_database:
     type: postgres:10
     portforward: true
+    app_mount: false
 proxy:
   pulfalight_test_solr:
     - pulfalight.test.solr.lndo.site:8983


### PR DESCRIPTION
Shaves off ~ 18 seconds from the test suite, and these services don't need the app mount anyways.