### PR TITLE
Fix test.

### DIFF
--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -185,7 +185,7 @@ describe "viewing catalog records", type: :feature, js: true do
       expect(page.body).to include "Middle East -- Politics"
     end
   end
-  context "when a component has a digital object with a manifest" do
+  context "when a component has a digital object with a manifest", js: false do
     before do
       visit "/catalog/MC221_c0094"
     end


### PR DESCRIPTION
I think tightening up CORS in Figgy meant the JS ran for this test and removed the readingroom container.