### PR TITLE
Index unpublished EADs, don't make them discoverable.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -45,7 +45,7 @@ class CatalogController < ApplicationController
   def show_query_params
     # Remove all filter queries from show - allows JSON for unpublished views to
     # be shown, for Figgy synchronizing.
-    if request.format == :json
+    if request.format == :json && params[:auth_token].to_s == Pulfalight.config["unpublished_auth_token"]
       { fq: [] }
     else
       {}

--- a/app/jobs/aspace_index_job.rb
+++ b/app/jobs/aspace_index_job.rb
@@ -46,7 +46,6 @@ class AspaceIndexJob < ApplicationJob
     ead_content = aspace_client.get_resource_description_xml(resource_descriptions_uri: resource_descriptions_uri, cached: soft)
     xml_documents = Nokogiri::XML.parse(ead_content)
     xml_documents.remove_namespaces!
-    return delete_document(xml_documents) if xml_documents.children[0]["audience"] == "internal"
 
     @repository_id = repository_id.try(&:downcase)
     solr_documents = EADArray.new
@@ -59,12 +58,5 @@ class AspaceIndexJob < ApplicationJob
     logger.info("Successfully indexed the EAD")
   rescue Pulfalight::MissingRepositoryError
     Honeybadger.notify("An Arclight::Repository was not found for repository_id #{repository_id} when indexing #{resource_descriptions_uri}. Check configuration in config/repositories.yml")
-  end
-
-  # Delete documents which are marked internal, in case they've been unpublished
-  # from ASpace, but were previously published.
-  def delete_document(xml_document)
-    ead_id = xml_document.xpath("//eadid").first.text.strip.tr(".", "-")
-    blacklight_connection.delete_by_id(ead_id)
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,7 +4,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Arclight::SearchBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
 
-  self.default_processor_chain += [:remove_grouping, :boost_collections, :strip_quotes]
+  self.default_processor_chain += [:remove_grouping, :boost_collections, :strip_quotes, :filter_unpublished]
 
   def remove_grouping(solr_params)
     # Remove grouping parameters if faceting by collection
@@ -20,5 +20,10 @@ class SearchBuilder < Blacklight::SearchBuilder
   def strip_quotes(solr_params)
     return unless solr_params[:q]
     solr_params[:qs] = 2
+  end
+
+  def filter_unpublished(solr_params)
+    solr_params[:fq] ||= []
+    solr_params[:fq] << "-audience_ssi:internal"
   end
 end

--- a/app/views/catalog/record_not_found.json.jbuilder
+++ b/app/views/catalog/record_not_found.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+json.set! :errors do
+  json.set! :message, "Not Found"
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   archivespace_user: <%= ENV["ASPACE_USER"] %>
   archivespace_password: <%= ENV["ASPACE_PASSWORD"] %>
   aeon_url: 'https://lib-aeon.princeton.edu/aeon/Aeon.dll'
+  unpublished_auth_token: <%= ENV["UNPUBLISHED_AUTH_TOKEN"] %>
 
 development:
   <<: *defaults
@@ -13,6 +14,7 @@ test:
   archivespace_url: "https://aspace.test.org/staff/api"
   archivespace_user: "test"
   archivespace_password: "password"
+  unpublished_auth_token: "123456"
 
 production:
   <<: *defaults

--- a/lib/pulfalight/traject/ead2_component_config.rb
+++ b/lib/pulfalight/traject/ead2_component_config.rb
@@ -52,6 +52,10 @@ to_field "ead_ssi" do |_record, accumulator, _context|
   accumulator << ead_ids.first if ead_ids.present?
 end
 
+to_field "audience_ssi" do |_record, accumulator, _context|
+  accumulator.concat settings[:root].output_hash["audience_ssi"]
+end
+
 to_field "title_filing_si", extract_xpath("./did/unittitle"), first_only
 to_field "title_ssm", extract_xpath("./did/unittitle")
 to_field "title_teim", extract_xpath("./did/unittitle")

--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -48,6 +48,11 @@ to_field "ead_ssi", extract_xpath("/ead/eadheader/eadid", to_text: false) do |_r
   string_array = string_array.map { |a| a.split("|").first }
   accumulator.replace(string_array)
 end
+
+to_field "audience_ssi", extract_xpath("/ead", to_text: false) do |_record, accumulator|
+  audience = accumulator[0].attributes["audience"].to_s
+  accumulator.replace([audience])
+end
 # rubocop:enable Performance/StringReplacement
 
 to_field "title_filing_si", extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -22,8 +22,12 @@ describe "catalog searches", type: :feature, js: true do
       visit "/catalog/C0744-04"
       expect(page).to have_content "The page you were looking for doesn't exist."
     end
-    it "has a JSON endpoint" do
+    it "doesn't normally return JSON" do
       visit "/catalog/C0744-04_c0117.json"
+      expect(page).to have_content "Not Found"
+    end
+    it "returns JSON if given an auth token" do
+      visit "/catalog/C0744-04_c0117.json?auth_token=#{Pulfalight.config['unpublished_auth_token']}"
       expect(page).to have_content "Garrett Ethiopic Magic Scroll No. 23"
     end
   end

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -13,6 +13,21 @@ describe "catalog searches", type: :feature, js: true do
     end
   end
 
+  context "when searching for an unpublished collection", js: false do
+    it "does not return it" do
+      visit "/?search_field=all_fields&q=c0744.04"
+      expect(page).to have_content "No results found for your search"
+    end
+    it "doesn't return a show page" do
+      visit "/catalog/C0744-04"
+      expect(page).to have_content "The page you were looking for doesn't exist."
+    end
+    it "has a JSON endpoint" do
+      visit "/catalog/C0744-04_c0117.json"
+      expect(page).to have_content "Garrett Ethiopic Magic Scroll No. 23"
+    end
+  end
+
   context "when searching for a specific collection by title", js: false do
     before do
       visit "/?search_field=all_fields&q=david+e.+lilienthal+papers%2C+1900-1981"

--- a/spec/fixtures/aspace/mss/C1588-internal.xml
+++ b/spec/fixtures/aspace/mss/C1588-internal.xml
@@ -95,7 +95,7 @@
       <corpname audience="internal" authfilenumber="https://viaf.org/viaf/144654270" source="viaf">International Association of the Congo—Sources.</corpname>
     </controlaccess>
     <dsc>
-      <c id="aspace_C1588_c1" level="file">
+      <c id="aspace_C1588testinternal_c1" level="file">
         <did>
           <unittitle>Relating to Association Internationale du Congo Tenure</unittitle>
           <physdesc altrender="whole">

--- a/spec/jobs/aspace_index_job_spec.rb
+++ b/spec/jobs/aspace_index_job_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AspaceIndexJob do
     end
 
     context "when given an EAD which is suddenly internal" do
-      it "deletes the existing record and its children from solr" do
+      it "marks the existing record and its children as internal" do
         stub_aspace_login
         stub_aspace_ead(resource_descriptions_uri: "repositories/13/resources/5396", ead: "mss/C1588-internal.xml")
 
@@ -39,12 +39,12 @@ RSpec.describe AspaceIndexJob do
         described_class.perform_now(resource_descriptions_uri: "repositories/13/resources/5396", repository_id: "mss")
         connection.commit
 
-        items = connection.get("select", params: { q: "id:C1588testinternal" })
-        expect(items["response"]["numFound"]).to eq 0
-        items = connection.get("select", params: { q: "collection_unitid_ssm:C1588testinternal" })
-        expect(items["response"]["numFound"]).to eq 0
+        items = connection.get("select", params: { q: "id:C1588testinternal", fl: "audience_ssi" })
+        expect(items["response"]["docs"][0]["audience_ssi"]).to eq "internal"
+        items = connection.get("select", params: { q: "id:C1588testinternal_c1", fl: "audience_ssi" })
+        expect(items["response"]["docs"][0]["audience_ssi"]).to eq "internal"
       end
-      it "can delete an EAD with a period in it" do
+      it "can mark an EAD internal with a period in it" do
         stub_aspace_login
         stub_aspace_ead(resource_descriptions_uri: "repositories/13/resources/5396", ead: "mss/C1588-internal-period.xml")
 
@@ -52,15 +52,15 @@ RSpec.describe AspaceIndexJob do
         described_class.perform_now(resource_descriptions_uri: "repositories/13/resources/5396", repository_id: "mss")
         connection.commit
 
-        items = connection.get("select", params: { q: "id:C1588testinternal-01" })
-        expect(items["response"]["numFound"]).to eq 0
-        items = connection.get("select", params: { q: "collection_unitid_ssm:C1588testinternal-01" })
+        items = connection.get("select", params: { q: "id:C1588testinternal-01", fl: "audience_ssi" })
+        expect(items["response"]["docs"][0]["audience_ssi"]).to eq "internal"
+        items = connection.get("select", params: { q: "collection_unitid_ssm:C1588testinternal-01", fl: "audience_ssi" })
         expect(items["response"]["numFound"]).to eq 0
       end
     end
 
     context "when given an internal EAD" do
-      it "doesn't index it" do
+      it "indexes it with audience_ssi internal" do
         stub_aspace_login
         stub_aspace_ead(resource_descriptions_uri: "repositories/13/resources/5396", ead: "mss/C1588-internal.xml")
 
@@ -68,8 +68,8 @@ RSpec.describe AspaceIndexJob do
         described_class.perform_now(resource_descriptions_uri: "repositories/13/resources/5396", repository_id: "mss")
         connection.commit
 
-        items = connection.get("select", params: { q: "id:C1588testinternal" })
-        expect(items["response"]["numFound"]).to eq 0
+        items = connection.get("select", params: { q: "id:C1588testinternal", fl: "audience_ssi" })
+        expect(items["response"]["docs"][0]["audience_ssi"]).to eq "internal"
       end
     end
 


### PR DESCRIPTION
This allows Figgy to hit the JSON endpoints for non-discoverable resources, but doesn't show them in search results or the HTML/Raw routes.

Closes #1010
Closes pulibrary/figgy#5050

Ansible PR: https://github.com/pulibrary/princeton_ansible/pull/2990