### PR TITLE
Make COVID announcement banner dismissible

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,5 +1,5 @@
 <header class="lux">
-  <banner>
+  <banner dismissible>
     <heading level="h1" size="h3">Welcome to the new Finding Aids site!</heading>
     <p>Learn about
       <hyperlink href="https://library.princeton.edu/special-collections/services/virtual-services">


### PR DESCRIPTION
This was a minor change that came up when working with @sdellis last month. I added the "dismissible" keyword to the banner element but don't know how to make the color of the actual "x" darker for more contrast because I lack lux/vue knowledge...