### PR TITLE
Index acqinfo_teim

### DIFF
--- a/lib/pulfalight/traject/ead2_component_config.rb
+++ b/lib/pulfalight/traject/ead2_component_config.rb
@@ -487,6 +487,8 @@ end
 
 to_field "acqinfo_ssim", extract_xpath('./acqinfo/*[local-name()!="head"]')
 to_field "acqinfo_ssim", extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
+to_field "acqinfo_teim", extract_xpath('./acqinfo/*[local-name()!="head"]')
+to_field "acqinfo_teim", extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
 to_field "acqinfo_ssm" do |_record, accumulator, context|
   accumulator.concat(context.output_hash.fetch("acqinfo_ssim", []))
 end

--- a/lib/pulfalight/traject/ead2_config.rb
+++ b/lib/pulfalight/traject/ead2_config.rb
@@ -232,6 +232,8 @@ to_field "access_terms_ssm", extract_xpath('/ead/archdesc/userestrict/*[local-na
 
 to_field "acqinfo_ssim", extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
 to_field "acqinfo_ssim", extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
+to_field "acqinfo_teim", extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
+to_field "acqinfo_teim", extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
 to_field "acqinfo_ssm" do |_record, accumulator, context|
   accumulator.concat(context.output_hash.fetch("acqinfo_ssim", []))
 end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -405,6 +405,16 @@ describe "EAD 2 traject indexing", type: :feature do
       end
     end
 
+    describe "collection history indexing" do
+      let(:fixture_path) do
+        Rails.root.join("spec", "fixtures", "aspace", "generated", "publicpolicy", "MC221.processed.EAD.xml")
+      end
+
+      it "indexes acqinfo_teim" do
+        expect(result["acqinfo_teim"]).not_to be_empty
+      end
+    end
+
     describe "collection notes indexing" do
       let(:fixture_path) do
         Rails.root.join("spec", "fixtures", "aspace", "generated", "publicpolicy", "MC221.processed.EAD.xml")


### PR DESCRIPTION
Works towards #935 

Fixes issue where acqinfo values are not searchable and do not appear in hit highlighting.