### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/assets/stylesheets/layouts/catalog_show.scss
+++ b/app/assets/stylesheets/layouts/catalog_show.scss
@@ -143,13 +143,9 @@
 
   .content-container {
     .navbar {
-      top: calc(100% - 4rem);
-
-      background: $background-gray;
-      border-top: solid 1px $light-border-gray;
-      border-bottom: solid 1px $light-border-gray;
-      margin-left: 0;
-      margin-right: 0;
+      bottom: 0;
+      background-color: $background-gray;
+      border: solid 1px $light-border-gray;
       padding-left: 0;
       padding-right: 0;
 
@@ -175,6 +171,10 @@
           padding-right: 0;
         }
       }
+    }
+
+    .tab-content {
+      margin-top: 4rem;
     }
 
     .tab-pane {

--- a/app/assets/stylesheets/layouts/home.scss
+++ b/app/assets/stylesheets/layouts/home.scss
@@ -1,6 +1,5 @@
 .header__secondary.home-header {
   position: relative;
-  overflow: hidden;
   h1 {
     color: #ffffff;
     position: relative;

--- a/app/assets/stylesheets/layouts/home.scss
+++ b/app/assets/stylesheets/layouts/home.scss
@@ -60,6 +60,7 @@
     @extend .col-lg-4;
     .request-header {
       h2 {
+        @extend .text-left;
         margin-bottom: 0;
       }
     }
@@ -70,7 +71,6 @@
       padding-top: 1.50rem;
 
     #request-registration {
-      @extend .text-justify;
       a {
         @extend .btn;
         @extend .btn-primary;
@@ -84,7 +84,7 @@
     @extend .col-lg-4;
     .feedback-welcome-header {
       h2 {
-        @extend .text-justify;
+        @extend .text-left;
         margin-bottom: 0;
       }
     }
@@ -101,7 +101,7 @@
       > div {
         @extend .col-md-12;
         > h2 {
-          @extend .text-justify;
+          @extend .text-left;
         }
       }
     }
@@ -124,7 +124,7 @@
       }
     }
     #more-hours {
-      @extend .text-justify;
+      @extend .text-left;
       a {
         @extend .btn;
         @extend .btn-primary;

--- a/app/assets/stylesheets/modules/buttons.scss
+++ b/app/assets/stylesheets/modules/buttons.scss
@@ -47,8 +47,8 @@
   align-self: start;
 }
 
-@media only screen and (max-width: 1100px) {
+@media only screen and (max-width: 960px) {
   .sticky-top {
-    flex-wrap: wrap;
+    flex-direction: column;
   }
 }

--- a/app/javascript/components/ChildTable.vue
+++ b/app/javascript/components/ChildTable.vue
@@ -87,13 +87,16 @@ export default {
 </script>
 
 <style lang="scss">
-  .child-component-table caption {
+.child-component-table {
+  overflow: scroll;
+  caption {
     caption-side: top;
   }
-  .child-component-table table {
+  table {
     width: 100%;
     th.loader {
       text-align: center;
     }
-  }
+}
+}
 </style>

--- a/app/views/catalog/_requests.html.erb
+++ b/app/views/catalog/_requests.html.erb
@@ -1,6 +1,6 @@
 <div class="request-header">
   <div>
-    <h2 class="text-justify">Request Materials</h2>
+    <h2>Request Materials</h2>
   </div>
 </div>
 <div id="request-contents">

--- a/app/views/catalog/_show_collection_expanded.html.erb
+++ b/app/views/catalog/_show_collection_expanded.html.erb
@@ -52,20 +52,6 @@
 
       <div class="col-md-8">
         <div class="tab-content">
-          <nav class="navbar sticky-top">
-            <div class="row">
-              <div class="col-md-4"></div>
-              <div class="col-md-4">
-                <a href="#correction" data-toggle="modal" data-target="#correctionModal">
-                  <%= image_tag(asset_path('icon-correction.svg'), "aria-label": "suggest correction icon") %>
-                  Suggest a correction
-                </a>
-
-                <%= render "correction_modal" %>
-              </div>
-            </div><!-- .row -->
-          </nav>
-
           <div class='tab-pane active' id='summary' role='tabpanel'>
             <%= render(partial: 'collection_summary_expanded') %>
           </div>
@@ -81,6 +67,19 @@
           <div class='tab-pane' id='find-more' role='tabpanel'>
             <%= render(partial: 'collection_find_more') %>
           </div>
+          <nav class="navbar sticky-top">
+            <div class="row">
+              <div class="col-md-4"></div>
+              <div class="col-md-4">
+                <a href="#correction" data-toggle="modal" data-target="#correctionModal">
+                  <%= image_tag(asset_path('icon-correction.svg'), "aria-label": "suggest correction icon") %>
+                  Suggest a correction
+                </a>
+
+                <%= render "correction_modal" %>
+              </div>
+            </div><!-- .row -->
+          </nav>
         </div><!-- .tab-content -->
       </div><!-- .col-md-8 -->
     </div><!-- .row.content-container -->

--- a/app/views/catalog/_show_tab_panes.html.erb
+++ b/app/views/catalog/_show_tab_panes.html.erb
@@ -1,98 +1,99 @@
 <div class="tab-content">
 
-  <nav class="navbar sticky-top lux">
-      <div>
-        <% if @document.aeon_request.requestable? %>
-          <add-to-cart-button
-            class="add-to-cart-block sticky-button"
-            <% @document.aeon_request.attributes.each_pair do |key, value| %>
-              <% unless value.nil? || value.empty? %>
-                <%= key %>="<%= value %>"
-              <% end %>
-            <% end %>
-            :form-params="<%= JSON.generate(@document.aeon_request.form_attributes) %>"
-            >
-            <lux-icon-base icon-name="add-to-cart" width="20" height="20">
-                <add-to-cart-icon></add-to-cart-icon>
-            </lux-icon-base>
-            <span>
-              Request This Box
-            </span>
-          </add-to-cart-button>
-        <% end %>
-      </div>
-      <div>
-        <input-button id="question-button" class="sticky-button" type="button" variation="text" data-toggle="modal" data-target="#questionModal">
-          <lux-icon-base icon-name="question" width="16" height="16">
-              <lux-icon-question></lux-icon-question>
-          </lux-icon-base>
-          <span>
-            Ask A Question
-          </span>
-        </input-button>
-        <%= render "question_modal" %>
-      </div>
-      <div>
-        <input-button id="correction-button" class="sticky-button" type="button" variation="text" data-toggle="modal" data-target="#correctionModal">
-          <lux-icon-base icon-name="correction-button-exclamation" width="16" height="16">
-              <lux-icon-exclamation></lux-icon-exclamation>
-          </lux-icon-base>
-          <span>
-            Suggest A Correction
-          </span>
-        </input-button>
-        <%= render "correction_modal" %>
-      </div>
-      <div>
-          <input-button id="harmful-language-button" class="sticky-button" type="button" variation="text" data-toggle="modal" data-target="#harmfulLanguageModal">
-            <lux-icon-base icon-name="exclamation" width="16" height="16">
-                <lux-icon-exclamation></lux-icon-exclamation>
-            </lux-icon-base>
-            <span>
-              Report Harmful Language or Content
-            </span>
-          </input-button>
-        <%= render "harmful_language_modal" %>
-      </div>
-  </nav>
-
   <% unless document.collection? %>
     <div class='tab-pane' id='component-summary' role='tabpanel'>
       <%= render(partial: 'component_summary') %>
     </div>
   <% end %>
 
-    <div class='tab-pane' id='summary' role='tabpanel'>
-      <div class="document-title">
-        <h2>Collection Overview</h2>
-      </div>
-      <%= render(partial: 'collection_summary') if document.collection? %>
+  <div class='tab-pane' id='summary' role='tabpanel'>
+    <div class="document-title">
+      <h2>Collection Overview</h2>
     </div>
+    <%= render(partial: 'collection_summary') if document.collection? %>
+  </div>
 
-    <div class='tab-pane' id='description' role='tabpanel'>
-      <div class="document-title">
-        <h2>Collection Description &amp; Creator Information</h2>
-      </div>
-      <%= render(partial: 'collection_description') %>
+  <div class='tab-pane' id='description' role='tabpanel'>
+    <div class="document-title">
+      <h2>Collection Description &amp; Creator Information</h2>
     </div>
-    <div class='tab-pane' id='collection-history' role='tabpanel'>
-      <div class="document-title">
-        <h2>Collection History</h2>
-      </div>
-      <%= render(partial: 'collection_history') %>
-    </div>
+    <%= render(partial: 'collection_description') %>
+  </div>
 
-    <div class='tab-pane' id='access' role='tabpanel'>
-      <div class="document-title">
-        <h2>Access &amp; Use </h2>
-      </div>
-      <%= render(partial: 'collection_access') %>
+  <div class='tab-pane' id='collection-history' role='tabpanel'>
+    <div class="document-title">
+      <h2>Collection History</h2>
     </div>
+    <%= render(partial: 'collection_history') %>
+  </div>
 
-    <div class='tab-pane' id='find-more' role='tabpanel'>
-      <div class="document-title">
-        <h2>Find More</h2>
-      </div>
-      <%= render(partial: 'collection_find_more') %>
+  <div class='tab-pane' id='access' role='tabpanel'>
+    <div class="document-title">
+      <h2>Access &amp; Use </h2>
     </div>
-  </div><!-- .tab-content -->
+    <%= render(partial: 'collection_access') %>
+  </div>
+
+  <div class='tab-pane' id='find-more' role='tabpanel'>
+    <div class="document-title">
+      <h2>Find More</h2>
+    </div>
+    <%= render(partial: 'collection_find_more') %>
+  </div>
+
+  <nav class="navbar sticky-top lux">
+      <% if @document.aeon_request.requestable? %>
+        <div>
+          <add-to-cart-button
+              class="add-to-cart-block sticky-button"
+              <% @document.aeon_request.attributes.each_pair do |key, value| %>
+              <% unless value.nil? || value.empty? %>
+                <%= key %>="<%= value %>"
+              <% end %>
+            <% end %>
+              :form-params="<%= JSON.generate(@document.aeon_request.form_attributes) %>"
+              >
+              <lux-icon-base icon-name="add-to-cart" width="20" height="20">
+                <add-to-cart-icon></add-to-cart-icon>
+              </lux-icon-base>
+              <span>
+                Request This Box
+              </span>
+          </add-to-cart-button>
+        </div>
+      <% end %>
+    <div>
+      <input-button id="question-button" class="sticky-button" type="button" variation="text" data-toggle="modal" data-target="#questionModal">
+        <lux-icon-base icon-name="question" width="16" height="16">
+          <lux-icon-question></lux-icon-question>
+        </lux-icon-base>
+        <span>
+          Ask A Question
+        </span>
+      </input-button>
+      <%= render "question_modal" %>
+    </div>
+    <div>
+      <input-button id="correction-button" class="sticky-button" type="button" variation="text" data-toggle="modal" data-target="#correctionModal">
+        <lux-icon-base icon-name="correction-button-exclamation" width="16" height="16">
+          <lux-icon-exclamation></lux-icon-exclamation>
+        </lux-icon-base>
+        <span>
+          Suggest A Correction
+        </span>
+      </input-button>
+      <%= render "correction_modal" %>
+    </div>
+    <div>
+      <input-button id="harmful-language-button" class="sticky-button" type="button" variation="text" data-toggle="modal" data-target="#harmfulLanguageModal">
+        <lux-icon-base icon-name="exclamation" width="16" height="16">
+          <lux-icon-exclamation></lux-icon-exclamation>
+        </lux-icon-base>
+        <span>
+          Report Harmful Language or Content
+        </span>
+      </input-button>
+      <%= render "harmful_language_modal" %>
+    </div>
+  </nav>
+</div><!-- .tab-content -->


### PR DESCRIPTION
Advances #111 

### Left align homepage headings instead of justifying
Before
<img width="377" alt="Screen Shot 2022-09-21 at 2 54 30 PM" src="https://user-images.githubusercontent.com/66143640/191587336-dc58a974-1239-415a-a602-8d1970c69525.png">

After
<img width="379" alt="Screen Shot 2022-09-21 at 2 54 21 PM" src="https://user-images.githubusercontent.com/66143640/191587372-31173155-761c-45e8-aab8-245528c30d97.png">

### Fix overflow of collection content list
Before
<img width="367" alt="Screen Shot 2022-09-21 at 2 57 10 PM" src="https://user-images.githubusercontent.com/66143640/191587719-0da5e3eb-6b93-4c1b-9dc6-beddb114ac59.png">

After
<img width="345" alt="Screen Shot 2022-09-21 at 2 57 55 PM" src="https://user-images.githubusercontent.com/66143640/191587858-60fbbf19-57bd-42be-b15c-2492fc4486d8.png">

### Fix bottom toolbar stickiness and wrapping
Before
<img width="428" alt="Screen Shot 2022-09-21 at 3 44 57 PM" src="https://user-images.githubusercontent.com/66143640/191596537-3e9aca0f-77c7-4784-90bc-a5977d66c303.png">

After
<img width="427" alt="Screen Shot 2022-09-21 at 3 45 09 PM" src="https://user-images.githubusercontent.com/66143640/191596559-b7b98d0b-d5fd-4dfb-a13d-13671e621996.png">

### Stop autocomplete options from being cutoff
Before
<img width="426" alt="Screen Shot 2022-09-21 at 3 04 19 PM" src="https://user-images.githubusercontent.com/66143640/191589125-385988eb-b60a-4c4c-9582-7c6669490c33.png">

After
<img width="426" alt="Screen Shot 2022-09-21 at 3 04 06 PM" src="https://user-images.githubusercontent.com/66143640/191589142-65d9fdd2-df64-44fb-b917-ed0f41860f7d.png">
