### PR TITLE
Remove audience filters

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -104,9 +104,7 @@ class CatalogController < ApplicationController
     # }
 
     config.default_document_solr_params = {
-      fl: "*",
-      # Block unpublished EADs from being navigated to.
-      fq: ["id:[* TO *] -audience_ssi:internal"]
+      fl: "*"
     }
 
     # solr field configuration for search results/index views

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,7 +4,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Arclight::SearchBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
 
-  self.default_processor_chain += [:remove_grouping, :boost_collections, :strip_quotes, :filter_unpublished]
+  self.default_processor_chain += [:remove_grouping, :boost_collections, :strip_quotes]
 
   def remove_grouping(solr_params)
     # Remove grouping parameters if faceting by collection
@@ -20,11 +20,6 @@ class SearchBuilder < Blacklight::SearchBuilder
   def strip_quotes(solr_params)
     return unless solr_params[:q]
     solr_params[:qs] = 2
-  end
-
-  def filter_unpublished(solr_params)
-    solr_params[:fq] ||= []
-    solr_params[:fq] << "-audience_ssi:internal"
   end
 
   # Override upstream highlighting method to add custom highlight field


### PR DESCRIPTION
Once prod is finished reindexing these won't be needed anymore because
there won't be any unpublished records in the index.

closes #1010
