### PR TITLE
Allow collapsing of Table of Contents

### DIFF
--- a/app/assets/stylesheets/layouts/collection_show.scss
+++ b/app/assets/stylesheets/layouts/collection_show.scss
@@ -1,9 +1,9 @@
 
 .blacklight-collection {
   .toc-header {
-    span:first-child {
-      margin-right: 0.85rem;
-      text-transform: uppercase;
+    .toc-header-text {
+      display: flex;
+      flex-direction: column;
     }
 
     &__expand-button {
@@ -19,7 +19,6 @@
       img {
         margin-left: 0.2rem;
         margin-right: 0.2rem;
-
         width: 0.85rem;
       }
 

--- a/app/assets/stylesheets/modules/toc.scss
+++ b/app/assets/stylesheets/modules/toc.scss
@@ -33,8 +33,24 @@
 }
 
 .toc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   background-color: $botticelli;
   font-weight: 500;
   margin-top: 20px;
-  padding: 15px 0 15px 10px;
+  padding: 15px 10px;
+
+  .toc-toggle {
+    font-size: 28px;
+    align-self: flex-end;
+
+    .collapsed .dropdown-toggle::after{
+      transform: rotate(0deg);
+    }
+
+    .dropdown-toggle::after{
+      transform: rotate(180deg);
+    }
+  }
 }

--- a/app/assets/stylesheets/modules/toc.scss
+++ b/app/assets/stylesheets/modules/toc.scss
@@ -42,15 +42,19 @@
   padding: 15px 10px;
 
   .toc-toggle {
-    font-size: 28px;
-    align-self: flex-end;
+    font-size: 1rem;
 
-    .collapsed .dropdown-toggle::after{
-      transform: rotate(0deg);
+    .toggle-icon::after{
+      content: "❯";
+      float: right;
+      margin-right: 0.2rem;
+      transform: rotate(270deg);
+      transition: transform 0.1s ease;
     }
 
-    .dropdown-toggle::after{
-      transform: rotate(180deg);
+    .collapsed .toggle-icon::after{
+      transform: rotate(90deg);
+      transition: transform 0.1s ease;
     }
   }
 }

--- a/app/javascript/pulfalight/media_queries.es6
+++ b/app/javascript/pulfalight/media_queries.es6
@@ -1,0 +1,20 @@
+export default class MediaQueries {
+  handleMobileChange(mediaQueryObj) {
+    // checks if it has hit the breakpoint specified when creating the query
+    if (mediaQueryObj.matches) { 
+      $('#toc').collapse('hide')
+    }
+  }
+
+  // collapses the table of contents once the screen width is a mobile size
+  setupTableCollapse() {
+    // using medium breakpoint from app/assets/stylesheets/variables/breaks.scss
+    const mediaQuery = window.matchMedia('(max-width: 768px)')
+    mediaQuery.addListener(this.handleMobileChange)
+    this.handleMobileChange(mediaQuery)
+  }
+
+  build() {
+    this.setupTableCollapse()
+  }
+}

--- a/app/javascript/pulfalight/pulfalight_loader.es6
+++ b/app/javascript/pulfalight/pulfalight_loader.es6
@@ -13,6 +13,7 @@ import LibCalHours from "../pulfalight/lib_cal_hours.es6"
 import ChildTable from "../components/ChildTable"
 import PulfaDataTable from "../components/PulfaDataTable"
 import FiggyViewer from "../components/FiggyViewer"
+import MediaQueries from "../pulfalight/media_queries.es6"
 
 export default class {
   run() {
@@ -21,7 +22,7 @@ export default class {
     this.setup_lib_cal_hours()
     this.setup_range_limit()
     this.setup_form_modal()
-    this.setup_toc_collapse()
+    this.setup_media_queries()
   }
 
   setup_lib_cal_hours() {
@@ -46,15 +47,9 @@ export default class {
     toc.build()
   }
 
-  setup_toc_collapse() {
-    const mediaQuery = window.matchMedia('(max-width: 768px)')
-    function handle_mobile_change(e) {
-      if (e.matches) {
-        $('#toc').collapse('hide')
-      }
-    }
-    mediaQuery.addListener(handle_mobile_change)
-    handle_mobile_change(mediaQuery)
+  setup_media_queries() {
+    const mediaQueries = new MediaQueries()
+    mediaQueries.build()
   }
 
   setup_vue() {

--- a/app/javascript/pulfalight/pulfalight_loader.es6
+++ b/app/javascript/pulfalight/pulfalight_loader.es6
@@ -21,6 +21,7 @@ export default class {
     this.setup_lib_cal_hours()
     this.setup_range_limit()
     this.setup_form_modal()
+    this.setup_toc_collapse()
   }
 
   setup_lib_cal_hours() {
@@ -43,6 +44,17 @@ export default class {
   setup_toc() {
     const toc = new TocBuilder('#toc')
     toc.build()
+  }
+
+  setup_toc_collapse() {
+    const mediaQuery = window.matchMedia('(max-width: 768px)')
+    function handle_mobile_change(e) {
+      if (e.matches) {
+        $('#toc').collapse('hide')
+      }
+    }
+    mediaQuery.addListener(handle_mobile_change)
+    handle_mobile_change(mediaQuery)
   }
 
   setup_vue() {

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -11,13 +11,21 @@
     <div class="row content-container">
       <div class="col-md-4">
         <div class="toc-header">
-          <span>Contents and Arrangement</span>
-          <a class="toc-header__expand-button" href="?expanded=true" >
-            <%= image_tag(asset_path('icon-expand-alt-solid.svg'), class: 'expand-collection-icon', "aria-label": "expand the collection view") %>
-            <span>Expanded View</span>
-          </a>
+          <div class="toc-header-text">
+            <span class="text-uppercase">Contents and Arrangement</span>
+            <a class="toc-header__expand-button" href="?expanded=true" >
+              <%= image_tag(asset_path('icon-expand-alt-solid.svg'), class: 'expand-collection-icon', "aria-label": "expand the collection view") %>
+              <span>Expanded View</span>
+            </a>
+          </div>
+          <div class="toc-toggle">
+            <a data-toggle="collapse" href="#toc" role="button">
+              <span class="sr-only">Toggle</span>
+              <span class="dropdown-toggle"></span>
+            </a>
+          </div>
         </div>
-        <div id="toc" data-turbolinks-permanent></div>
+        <div id="toc" data-turbolinks-permanent class="collapse show"></div>
         <div id="toc-data" data-selected="<%= document.id %>"></div>
       </div>
 

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -21,7 +21,7 @@
           <div class="toc-toggle">
             <a data-toggle="collapse" href="#toc" role="button">
               <span class="sr-only">Toggle</span>
-              <span class="dropdown-toggle"></span>
+              <span class="toggle-icon"></span>
             </a>
           </div>
         </div>

--- a/app/views/catalog/_show_collection_expanded.html.erb
+++ b/app/views/catalog/_show_collection_expanded.html.erb
@@ -50,7 +50,7 @@
           <div class="toc-toggle">
             <a data-toggle="collapse" href="#toc" role="button">
               <span class="sr-only">Toggle</span>
-              <span class="dropdown-toggle"></span>
+              <span class="toggle-icon"></span>
             </a>
           </div>
         </div>

--- a/app/views/catalog/_show_collection_expanded.html.erb
+++ b/app/views/catalog/_show_collection_expanded.html.erb
@@ -40,13 +40,21 @@
     <div class="row content-container">
       <div class="col-md-4">
         <div class="toc-header">
-          <span>Contents and Arrangement</span>
-          <a class="toc-header__expand-button" href="<%= solr_document_url(document) %>">
-            <%= image_tag(asset_path('icon-compress-alt-solid.svg'), class: 'compress-collection-icon', "aria-label": "view the collection in the default mode") %>
-            <span>Collection View</span>
-          </a>
+          <div class="toc-header-text">
+            <span class="text-uppercase">Contents and Arrangement</span>
+            <a class="toc-header__expand-button" href="<%= solr_document_url(document) %>">
+              <%= image_tag(asset_path('icon-compress-alt-solid.svg'), class: 'compress-collection-icon', "aria-label": "view the collection in the default mode") %>
+              <span>Collection View</span>
+            </a>
+          </div>
+          <div class="toc-toggle">
+            <a data-toggle="collapse" href="#toc" role="button">
+              <span class="sr-only">Toggle</span>
+              <span class="dropdown-toggle"></span>
+            </a>
+          </div>
         </div>
-        <div id="toc" data-turbolinks-permanent></div>
+        <div id="toc" data-turbolinks-permanent class="collapse show"></div>
         <div id="toc-data" data-selected="<%= document.id %>"></div>
       </div>
 

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -15,7 +15,7 @@
           <div class="toc-toggle">
             <a data-toggle="collapse" href="#toc" role="button">
               <span class="sr-only">Toggle</span>
-              <span class="dropdown-toggle"></span>
+              <span class="toggle-icon"></span>
             </a>
           </div>
         </div>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -9,9 +9,17 @@
     <div class="row content-container">
       <div class="col-md-4">
         <div class="toc-header">
-          <span>CONTENTS AND ARRANGEMENT</span>
+          <div>
+            <span class="text-uppercase">Contents and Arrangement</span>
+          </div>
+          <div class="toc-toggle">
+            <a data-toggle="collapse" href="#toc" role="button">
+              <span class="sr-only">Toggle</span>
+              <span class="dropdown-toggle"></span>
+            </a>
+          </div>
         </div>
-        <div id="toc" data-turbolinks-permanent></div>
+        <div id="toc" data-turbolinks-permanent class="collapse show"></div>
         <div id="toc-data" data-selected="<%= document.id %>"></div>
       </div>
 


### PR DESCRIPTION
Closes #111 by creating a collapsible Table of Contents so scrolling on mobile devices isn't trapped within it. Now, the Table of Contents will be collapsed by default on mobile devices.

Before
<img width="319" alt="Screen Shot 2022-10-03 at 4 40 59 PM" src="https://user-images.githubusercontent.com/66143640/193678569-8a70144d-6d7c-4ab8-815b-c49ccff68ef5.png">

After (Expanded)
<img width="322" alt="Screen Shot 2022-10-10 at 2 21 28 PM" src="https://user-images.githubusercontent.com/66143640/194929830-3227fe63-c5c5-485e-b109-693c4ff0938d.png">

After (Collapsed)
<img width="322" alt="Screen Shot 2022-10-10 at 2 21 16 PM" src="https://user-images.githubusercontent.com/66143640/194929836-28f5ff87-b53e-4b11-96b7-aa2a7aaf1dd1.png">