### PR TITLE
Make search bar autocomplete text invisible

### DIFF
--- a/app/assets/stylesheets/_overrides.scss
+++ b/app/assets/stylesheets/_overrides.scss
@@ -33,6 +33,7 @@ a {
 
 .twitter-typeahead {
     z-index: 998 !important;
+    background-color: white;
 }
 
 .lux-tabs-container {

--- a/app/assets/stylesheets/modules/search.scss
+++ b/app/assets/stylesheets/modules/search.scss
@@ -118,7 +118,7 @@ header .navbar-form .input-group .input-group-btn {
 }
 
 .search-q.form-control.tt-hint {
-  color: white;
+  visibility: hidden;
 }
 
 @media (min-width: $bp-large) {

--- a/app/assets/stylesheets/modules/search.scss
+++ b/app/assets/stylesheets/modules/search.scss
@@ -117,6 +117,10 @@ header .navbar-form .input-group .input-group-btn {
   height: $search-box-form-height;
 }
 
+.search-q.form-control.tt-hint {
+  color: white;
+}
+
 @media (min-width: $bp-large) {
   .navbar-form .input-group >
   .search-q.form-control {


### PR DESCRIPTION
closes #1171 

I decided to set the text color to white instead of using the suggested `filter: opacity(0);` because doing the latter made the whole search bar invisible. 