### PR TITLE
Set timeout for redis client

### DIFF
--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-require "redis"
-config = YAML.safe_load(ERB.new(IO.read(Rails.root.join("config", "redis.yml"))).result, aliases: true)[Rails.env].with_indifferent_access
-Redis.current = Redis.new(config.merge(thread_safe: true))

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
-require_relative "redis_config"
+require "redis"
+redis_config = YAML.safe_load(ERB.new(IO.read(Rails.root.join("config", "redis.yml"))).result, aliases: true)[Rails.env].with_indifferent_access
+redis_client = Redis.new(redis_config.merge(thread_safe: true))._client
+
 Sidekiq.configure_server do |config|
-  config.redis = Redis.current._client.options
+  config.redis = redis_client.options
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = Redis.current._client.options
+  config.redis = redis_client.options
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -8,6 +8,7 @@ production: &production
   host: <%= ENV['PULFALIGHT_REDIS_URL'] || 'localhost' %>
   port: <%= ENV['PULFALIGHT_REDIS_PORT'] || '6379' %>
   db: <%= ENV['PULFALIGHT_REDIS_DB'] || 1 %>
+  timeout: 30
 staging:
   <<: *production
 qa:


### PR DESCRIPTION
closes #1117

This updates the redis timeout and also updates the way we configure redis, doing it through the sidekiq initializer.

According to documentation, `Redis.current` should work still with the version of the redis gem used in pulfalight, but when I tried to access it it only returned default configurations.

Tested this new configuration on staging and jobs successfully process. And doing it this way should set us up for gem upgrades.

Used https://github.com/pulibrary/figgy/commit/14d7104803fc2bae176747b119f7928ae016ebe3 as a reference for this.