### PR TITLE
Render headers for collection description.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -391,7 +391,7 @@ class CatalogController < ApplicationController
     # =================================
     # COLLECTION DESCRIPTION TAB FIELDS
     # =================================
-    config.add_collection_description_field "collection_description_ssm", label: "Description", helper_method: :paragraph_separator, accessor: :fetch_html_safe
+    config.add_collection_description_field "scopecontent_ssm", label: "Description", helper_method: :paragraph_separator, accessor: :fetch_html_safe
     config.add_collection_description_field "arrangement_ssm", label: "Arrangement", helper_method: :paragraph_separator, accessor: :fetch_html_safe
     config.add_collection_description_field "collection_bioghist_ssm", label: "Collection Creator Biography", helper_method: :hr_separator, accessor: :fetch_html_safe
     config.add_collection_description_field "odd_ssm", label: "Note", helper_method: :paragraph_separator, accessor: :fetch_html_safe

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -287,8 +287,8 @@ describe "viewing catalog records", type: :feature, js: true do
         # Collection Description
         within("#description") do
           # Description
-          expect(page).to have_selector "dt.blacklight-collection_description_ssm", text: "Description"
-          expect(page).to have_selector "dd.blacklight-collection_description_ssm", text: /This collection consists of the papers of Lilienthal/
+          expect(page).to have_selector "dt.blacklight-scopecontent_ssm", text: "Scope and Contents"
+          expect(page).to have_selector "dd.blacklight-scopecontent_ssm", text: /This collection consists of the papers of Lilienthal/
           # Arrangement
           expect(page).to have_selector "dt.blacklight-arrangement_ssm", text: "Arrangement"
           expect(page).to have_selector "dd.blacklight-arrangement_ssm", text: /may have been put in this order by Lilienthal/


### PR DESCRIPTION
We were indexing all the right things, we just needed to use the scopecontent_ssm field instead of the collection_description_ssm, since that's the field that has the `_combined` field.

Closes #817

![Screen Shot 2023-07-05 at 9 19 28 AM](https://github.com/pulibrary/pulfalight/assets/2806645/ddfd4baf-2f2a-45e9-b82e-fb4f797d04c6)

![Screen Shot 2023-07-05 at 10 31 55 AM](https://github.com/pulibrary/pulfalight/assets/2806645/66ea1137-f250-46fb-9c1e-b81074bad9cd)

