### PR TITLE
Increase solr timeout.

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -19,6 +19,8 @@ test: &test
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] %>
+  timeout: 900
 staging:
   adapter: solr
   url: <%= ENV['SOLR_URL'] %>
+  timeout: 900


### PR DESCRIPTION
Closes #1262 

This allows indexing to work by waiting for Solr to update for a longer time. We think Solr might still have problems, but this gets pulfalight indexing.