### PR TITLE
Search results badge row

### DIFF
--- a/app/assets/stylesheets/layouts/catalog_show.scss
+++ b/app/assets/stylesheets/layouts/catalog_show.scss
@@ -106,14 +106,6 @@
     column-gap: 0.8rem;
   }
 
-  .document-extent {
-    @include document-extent-badge;
-  }
-
-  .document-access {
-    @include document-access-badge;
-  }
-
   .breadcrumbs {
     @include breadcrumbs;
   }

--- a/app/assets/stylesheets/layouts/catalog_show.scss
+++ b/app/assets/stylesheets/layouts/catalog_show.scss
@@ -103,7 +103,7 @@
 
   .document-attributes {
     display: inline-flex;
-    column-gap: 0.8rem;
+    column-gap: 0.4rem;
   }
 
   .breadcrumbs {
@@ -178,7 +178,7 @@
 
         .document-attributes {
           display: inline-flex;
-          column-gap: 0.8rem;
+          column-gap: 0.4rem;
         }
 
         .document-title {

--- a/app/assets/stylesheets/modules/_document_access_badge.scss
+++ b/app/assets/stylesheets/modules/_document_access_badge.scss
@@ -7,6 +7,7 @@
   font-weight: 500;
   gap: 0.4rem;
   align-items: center;
+  margin: 8px 0;
 
   &.online-content-banner {
     align-items: center;

--- a/app/assets/stylesheets/modules/_document_extent_badge.scss
+++ b/app/assets/stylesheets/modules/_document_extent_badge.scss
@@ -9,6 +9,7 @@
   border-width: 0.2rem;
   gap: 0.4rem;
   align-items: center;
+  margin: 8px 0;
 
   color: #0d6fd9;
   background-color: #f2f9fe;

--- a/app/presenters/online_content_badge.rb
+++ b/app/presenters/online_content_badge.rb
@@ -11,7 +11,7 @@ class OnlineContentBadge
 
   def render
     return unless document.has_digital_content?
-    tag.div(children, class: "document-access online-content #{badge_class}")
+    tag.span(children, class: "document-access online-content #{badge_class}")
   end
 
   private

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -8,22 +8,9 @@
     <div class="documentHeader my-w-75 w-md-100 order-0" data-document-id="<%= document.id %>">
       <h3 class="index_title document-title-heading">
         <%= link_to_document document, document_show_link_field(document), counter: counter %>
-
-
-        <%= content_tag('div', class: 'al-document-extent badge') do %>
-          <%= document.eadid %>
-        <% end if document.collection? %>
-
-        <% document.extents.each do |extent| %>
-          <%= content_tag('span', class: 'al-document-extent badge') do %>
-            <%= extent %>
-          <% end if extent %>
-        <% end %>
       </h3>
 
-      <div class="col col-no-left-padding d-flex flex-wrap">
-        <%= OnlineContentBadge.new(document).render %>
-      </div>
+      <%= render partial: 'index_document_attributes', locals: { document: document } %>
     </div>
 
     <div class="my-w-25 w-md-100 order-12 order-md-1">

--- a/app/views/catalog/_group_header_default.html.erb
+++ b/app/views/catalog/_group_header_default.html.erb
@@ -8,17 +8,7 @@
       <% end %>
       <h3><%= link_to_document document, document_show_link_field(document) %></h3>
 
-      <div>
-        <%= OnlineContentBadge.new(document).render %>
-      </div>
-
-      <%= content_tag('div', class: 'al-document-extent badge') do %>
-        <%= document.eadid %>
-      <% end if document.collection? %>
-
-      <%= content_tag('span', class: 'al-document-extent badge') do %>
-        <%= document.extent %>
-      <% end if document.extent %>
+      <%= render partial: 'index_document_attributes', locals: { document: document } %>
       <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
         <%= content_tag('div', 'data-arclight-truncate' => true) do %>
           <%= document.abstract_or_scope %>

--- a/app/views/catalog/_index_document_attributes.html.erb
+++ b/app/views/catalog/_index_document_attributes.html.erb
@@ -1,0 +1,13 @@
+      <%= content_tag('div', class: 'document-attributes d-flex flex-wrap') do %>
+        <%= content_tag('span', class: 'document-extent badge') do %>
+          <%= document.eadid %>
+        <% end if document.collection? %>
+
+        <% document.extents.each do |extent| %>
+          <%= content_tag('span', class: 'document-extent badge') do %>
+            <%= extent %>
+          <% end if extent %>
+        <% end %>
+
+        <%= OnlineContentBadge.new(document).render %>
+      <% end %>


### PR DESCRIPTION
- Remove duplicate styles
- Bring all badges into a row below the title

Makes the change for both index views: grouped and ungrouped
Uses badge styles that were initially developed for the component page,
so now they're blue in both places. Reduced gap between badges a bit on
both index and component page.

closes https://github.com/pulibrary/pulfalight/issues/1172

screenshots:
![Screenshot 2023-07-11 at 7 54 41 PM](https://github.com/pulibrary/pulfalight/assets/845363/da419cf4-a675-4310-b7a9-fb4d2d9edc93)
![Screenshot 2023-07-11 at 7 54 35 PM](https://github.com/pulibrary/pulfalight/assets/845363/133a7ad4-962c-4582-b313-0810bd917d22)
![Screenshot 2023-07-11 at 7 54 30 PM](https://github.com/pulibrary/pulfalight/assets/845363/d64c8dc5-3986-4475-9465-094149dc416f)
