### PR TITLE
Add library building to search results breadcrumbs

### DIFF
--- a/app/helpers/pulfalight_helper.rb
+++ b/app/helpers/pulfalight_helper.rb
@@ -90,6 +90,48 @@ module PulfalightHelper
     safe_join(children, separator)
   end
 
+  # Overrides:
+  # https://github.com/projectblacklight/arclight/blob/v0.4.0/app/helpers/arclight_helper.rb#L18
+  # @param [SolrDocument]
+  def parents_to_links(document)
+    breadcrumb_links = []
+
+    breadcrumb_links << build_repository_link(document)
+
+    breadcrumb_links << document_parents(document).map do |parent|
+      link_to parent.label, solr_document_path(parent.global_id)
+    end
+
+    # Add library location to breadcrumbs
+    url = solr_document_path(document.collection_document.id) + "#access"
+    breadcrumb_links.unshift(link_to(document.repository_config&.building, url))
+
+    safe_join(breadcrumb_links, aria_hidden_breadcrumb_separator)
+  end
+
+  # Overrides:
+  # https://github.com/projectblacklight/arclight/blob/v0.4.0/app/helpers/arclight_helper.rb#L38
+  # @param [SolrDocument]
+  def regular_compact_breadcrumbs(document)
+    breadcrumb_links = [build_repository_link(document)]
+
+    parents = document_parents(document)
+    breadcrumb_links << parents[0, 1].map do |parent|
+      link_to parent.label, solr_document_path(parent.global_id)
+    end
+
+    # Add library location to breadcrumbs
+    url = solr_document_path(document.collection_document.id) + "#access"
+    breadcrumb_links.unshift(link_to(document.repository_config&.building, url))
+
+    breadcrumb_links << "&hellip;".html_safe if parents.length > 1
+
+    safe_join(
+      breadcrumb_links,
+      aria_hidden_breadcrumb_separator
+    )
+  end
+
   private
 
   def repository_thumbnail_path

--- a/spec/helpers/pulfalight_helper_spec.rb
+++ b/spec/helpers/pulfalight_helper_spec.rb
@@ -122,4 +122,28 @@ describe PulfalightHelper, type: :helper do
       expect { helper.display_simple_link? }.not_to raise_error
     end
   end
+
+  describe "#parents_to_links" do
+    let(:component_document) do
+      SolrDocument.find("C0269")
+    end
+
+    it "displays the library location in the bread crumb links and it's url" do
+      element = helper.regular_compact_breadcrumbs(component_document)
+      expect(element).to include "Firestone Library"
+      expect(element).to include "/catalog/C0269#access"
+    end
+  end
+
+  describe "#regular_compact_breadcrumbs" do
+    let(:component_document) do
+      SolrDocument.find("C0269")
+    end
+
+    it "displays the library location in the bread crumb links and it's url" do
+      element = helper.regular_compact_breadcrumbs(component_document)
+      expect(element).to include "Firestone Library"
+      expect(element).to include "/catalog/C0269#access"
+    end
+  end
 end


### PR DESCRIPTION
Closes #1051 

Blocked by urls to assign to library buildings.

![Screenshot 2023-07-14 at 2 13 50 PM](https://github.com/pulibrary/pulfalight/assets/784196/2b6c5f7c-6d5c-4081-9190-a8b10fad3f41)


