### PR TITLE
Base location hint off of Site.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -279,12 +279,6 @@ class SolrDocument
     end
   end
 
-  def held_by_url
-    fetch("container_location_codes_ssim", []).map do |code|
-      Pulfalight::LocationCode.new(code).url if Pulfalight::LocationCode.registered?(code)
-    end
-  end
-
   def publisher
     fetch("collection_creator_ssm", [])
   end

--- a/app/values/aeon_request.rb
+++ b/app/values/aeon_request.rb
@@ -19,11 +19,24 @@ class AeonRequest
 
   def location_attributes
     note = Pulfalight::DeliveryNote.new(solr_document["container_location_codes_ssim"]&.first).brief_note
-    { notes: note, label: solr_document.held_by.first, url: held_by_url }
+    { notes: note, label: site_info[site][:label], url: site_info[site][:url] }
   end
 
-  def held_by_url
-    solr_document.held_by_url.first
+  def site_info
+    {
+      "RBSC" => {
+        label: "Firestone Library",
+        url: "https://library.princeton.edu/special-collections/visit-us"
+      },
+      "MUDD" => {
+        label: "Mudd Manuscript Library",
+        url: "https://library.princeton.edu/special-collections/visit-us"
+      },
+      "Engineering Library" => {
+        label: "Engineering Library",
+        url: "https://library.princeton.edu/engineering"
+      }
+    }
   end
 
   def form_attributes

--- a/spec/values/aeon_request_spec.rb
+++ b/spec/values/aeon_request_spec.rb
@@ -301,6 +301,7 @@ RSpec.describe AeonRequest do
       request_id = request.form_attributes[:Request]
       expect(request.form_attributes[:"Site_#{request_id}"]).to eq "RBSC"
       expect(request.location_attributes[:notes]).to be_nil
+      expect(request.location_attributes[:label]).to eq "Firestone Library"
     end
   end
   context "when it's a component with rcpph mapping" do
@@ -317,8 +318,8 @@ RSpec.describe AeonRequest do
       expect(request.form_attributes[:"Site_#{request_id}"]).to eq "MUDD"
       expect(request.form_attributes[:Location]).to eq "ReCAP"
       expect(request.location_attributes[:notes]).to eq "This item is stored offsite. Please allow up to 3 business days for delivery."
-      expect(request.location_attributes[:label]).to eq "ReCAP"
-      expect(request.location_attributes[:url]).to eq nil
+      expect(request.location_attributes[:label]).to eq "Mudd Manuscript Library"
+      expect(request.location_attributes[:url]).to eq "https://library.princeton.edu/special-collections/visit-us"
     end
   end
   context "when there's two boxes for one component" do


### PR DESCRIPTION
This fixes the problem where ReCAP would be displayed, which is not a site researchers can go to.

Closes #1154