### PR TITLE
Use refs instead of ID when fetching xml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,3 +112,5 @@ gem "net-smtp", require: false
 gem "strscan", "3.0.1"
 
 gem "vite_rails", "~> 3.0"
+
+gem "debug", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,9 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    debug (1.8.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     deprecation (1.1.0)
       activesupport
     descendants_tracker (0.0.4)
@@ -246,6 +249,10 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    io-console (0.6.0)
+    irb (1.9.1)
+      rdoc
+      reline (>= 0.3.8)
     jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -345,6 +352,8 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -391,8 +400,12 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     redis (4.8.1)
     regexp_parser (2.8.1)
+    reline (0.4.1)
+      io-console (~> 0.5)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -517,6 +530,7 @@ GEM
       net-ssh (>= 2.8.0)
     sshkit-interactive (0.3.0)
       sshkit (~> 1.12)
+    stringio (3.1.0)
     strscan (3.0.1)
     terser (1.1.12)
       execjs (>= 0.3.0, < 3)
@@ -624,6 +638,7 @@ DEPENDENCIES
   change_the_subject
   coffee-rails (~> 4.2)
   database_cleaner
+  debug (~> 1.8)
   devise (>= 4.7.1)
   devise-guests (~> 0.6)
   dotenv-rails

--- a/app/models/pulfalight/document/xml_export.rb
+++ b/app/models/pulfalight/document/xml_export.rb
@@ -11,7 +11,7 @@ module Pulfalight::Document::XMLExport
     document = add_pul_to_repository(document)
     return document if collection?
     document = document.remove_namespaces!
-    document.xpath("//*[@id='#{id}']")[0].to_xml
+    document.xpath("//*[@id='#{refs.first}']")[0].to_xml
   end
 
   def strip_containers(document)

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -51,6 +51,17 @@ describe "controller requests", type: :request do
         expect(ead_stub).to have_been_requested.once
         expect(search_stub).to have_been_requested.once
       end
+
+      it "works when the id has a dash but the ref has a dot" do
+        stub_aspace_login
+        stub_aspace_repositories
+        stub_search(repository_id: "13", resource_ids: ["AC198.10"]).last
+        stub_aspace_ead(resource_descriptions_uri: "repositories/13/resource_descriptions/AC198.10", ead: "generated/univarchives/AC198.10.processed.EAD.xml")
+
+        get "/catalog/AC198-10_c6.xml"
+
+        expect(response).to be_successful
+      end
       it "can be requested to not include containers" do
         stub_aspace_login
         stub_aspace_repositories


### PR DESCRIPTION
- Add debug gem to get around load errors with pry debugging
- Use refs when fetching document id, it stores the original id

closes #1116
