### PR TITLE
Background email

### DIFF
--- a/app/forms/ask_a_question_form.rb
+++ b/app/forms/ask_a_question_form.rb
@@ -26,7 +26,7 @@ class AskAQuestionForm
   end
 
   def submit
-    ContactMailer.with(form: self).contact.deliver
+    ContactMailer.with(form_params: as_json.except("validation_context", "errors"), form_class: self.class).contact.deliver_later
     @submitted = true
     @name = ""
     @email = ""

--- a/app/forms/report_harmful_language_form.rb
+++ b/app/forms/report_harmful_language_form.rb
@@ -7,7 +7,7 @@ class ReportHarmfulLanguageForm
   validates :email, email: true, allow_blank: true
 
   def submit
-    ContactMailer.with(form: self).report.deliver
+    ContactMailer.with(form_params: as_json.except("validation_context", "errors"), form_class: self.class).report.deliver_later
     @submitted = true
     @name = ""
     @email = ""

--- a/app/forms/suggest_a_correction_form.rb
+++ b/app/forms/suggest_a_correction_form.rb
@@ -7,7 +7,7 @@ class SuggestACorrectionForm
   validates :email, email: true
 
   def submit
-    ContactMailer.with(form: self).suggest.deliver
+    ContactMailer.with(form_params: as_json.except("validation_context", "errors"), form_class: self.class).suggest.deliver_later
     @submitted = true
     @name = ""
     @email = ""

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 class ContactMailer < ApplicationMailer
   def suggest
-    @form = params[:form]
+    @form = params[:form_class].new(params[:form_params])
     mail(to: @form.routed_mail_to, from: @form.email, subject: "Suggest a Correction")
   end
 
   def report
-    @form = params[:form]
+    @form = params[:form_class].new(params[:form_params])
     if @form.email.blank?
       mail(to: @form.routed_mail_to, from: "anonymous@princeton.edu", subject: "Reporting Harmful Language")
     else
@@ -15,7 +15,7 @@ class ContactMailer < ApplicationMailer
   end
 
   def contact
-    @form = params[:form]
+    @form = params[:form_class].new(params[:form_params])
     mail(to: @form.routed_mail_to, from: @form.email, subject: @form.email_subject)
   end
 end


### PR DESCRIPTION
This will let us only send emails from worker nodes, which will stop errors from showing to users and let us retry emails that come in.

Work in response to #1361