### PR TITLE
Don't hide component summary for c_ids without underscores.

### DIFF
--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,7 +1,18 @@
+function isCollectionLandingPage(url) {
+  // If there's an underscore it's a component page
+  if(url.href.includes("_"))
+    return false;
+  // If there's a component summary it's a component page.
+  else if($("#component-summary").length > 0)
+    return false;
+  else
+    return true;
+}
 $( document ).ready(function() {
   const url = new URL(window.location);
   $(".lux-tabs-container li").removeClass( "active" );
-  if(!url.href.includes("_") && !url.hash && $("#component-summary").length == 0){
+  // Default to summary tab if it's a collection landing page.
+  if(!url.hash && isCollectionLandingPage(url)){
     url.hash = '#summary';
   }
   switch (url.hash) {

--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,7 +1,7 @@
 $( document ).ready(function() {
   const url = new URL(window.location);
   $(".lux-tabs-container li").removeClass( "active" );
-  if(!url.href.includes("_") && !url.hash){
+  if(!url.href.includes("_") && !url.hash && $("#component-summary").length == 0){
     url.hash = '#summary';
   }
   switch (url.hash) {

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -13,6 +13,10 @@ describe "viewing catalog records", type: :feature, js: true do
       visit "catalog/C1588_c9"
       expect(page).to have_css(".document-title > h2", text: "Unused AIC Supply Request Form, circa 1885")
     end
+    it "renders components that don't have the parent in the name" do
+      visit "/catalog/ref312"
+      expect(page).to have_css(".document-title > h2", text: "Mittens for Kittens")
+    end
     it "renders content warning headings that were inherited" do
       visit "catalog/TC040_c00002"
 


### PR DESCRIPTION
Closes #1380

As an aside, this tab situation's quite a lot. We render all the tabs on every page, but don't switch to them with javascript. It's very odd, artifact of implementing wireframes out of Arclight probably?