### PR TITLE
Add a context for errors in maintenance window.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/initializers/simple_form_bootstrap.rb'
     - 'lib/pulfalight/traject/ead2_component_config.rb'
+Rails/UnknownEnv:
+  Exclude:
+    - 'config/initializers/honeybadger_downtime_hook.rb'
 Metrics/ClassLength:
   Exclude:
     - 'app/models/solr_document.rb'

--- a/config/initializers/honeybadger_downtime_hook.rb
+++ b/config/initializers/honeybadger_downtime_hook.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# We have a maintenance window every Monday for Staging and Tuesday for
+# production, from 5:30 AM to 8:30 AM.
+class HoneybadgerCheck
+  def self.maintenance_window?
+    return false unless Rails.env.staging? || Rails.env.production?
+    # Check in Eastern time.
+    Time.use_zone("America/New_York") do
+      current_time = Time.zone.now
+      # Only check times if we're the correct day of the week.
+      return false if Rails.env.staging? && !current_time.monday?
+      return false if Rails.env.production? && !current_time.tuesday?
+      current_time.between?(Time.zone.parse("5:30"), Time.zone.parse("8:30"))
+    end
+  end
+end
+Honeybadger.configure do |config|
+  config.before_notify do |notice|
+    # Add a maintenance_window tag - tags seems to be a comma delimited string,
+    # so split them, add the maintenance_window one, and rejoin them.
+    notice.context[:maintenance_window] = "true" if HoneybadgerCheck.maintenance_window?
+  end
+end

--- a/spec/honeybadger_spec.rb
+++ b/spec/honeybadger_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe HoneybadgerCheck do
+  describe ".maintenance_window?" do
+    context "when it's staging" do
+      context "and in the maintenance window" do
+        it "returns true" do
+          allow(Rails.env).to receive(:staging?).and_return(true)
+          Timecop.freeze("2024-07-08 5:40 AM EDT -04:00") do
+            expect(described_class.maintenance_window?).to eq true
+          end
+        end
+      end
+      context "in the wrong day" do
+        it "returns false" do
+          allow(Rails.env).to receive(:staging?).and_return(true)
+          Timecop.freeze("2024-07-09 5:40 AM EDT -04:00") do
+            expect(described_class.maintenance_window?).to eq false
+          end
+        end
+      end
+      context "in the wrong time" do
+        it "returns false" do
+          allow(Rails.env).to receive(:staging?).and_return(true)
+          Timecop.freeze("2024-07-08 5:00 AM EDT -04:00") do
+            expect(described_class.maintenance_window?).to eq false
+          end
+        end
+      end
+    end
+    context "when it's production" do
+      context "and in the maintenance window" do
+        it "returns true" do
+          allow(Rails.env).to receive(:production?).and_return(true)
+          Timecop.freeze("2024-07-09 5:40 AM EDT -04:00") do
+            expect(described_class.maintenance_window?).to eq true
+          end
+        end
+      end
+      context "in the wrong day" do
+        it "returns false" do
+          allow(Rails.env).to receive(:production?).and_return(true)
+          Timecop.freeze("2024-07-08 5:40 AM EDT -04:00") do
+            expect(described_class.maintenance_window?).to eq false
+          end
+        end
+      end
+      context "in the wrong time" do
+        it "returns false" do
+          allow(Rails.env).to receive(:production?).and_return(true)
+          Timecop.freeze("2024-07-09 5:00 AM EDT -04:00") do
+            expect(described_class.maintenance_window?).to eq false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Work towards pulibrary/figgy#6394

This enables us to do a search in Honeybadger to exclude all maintenance items: `-context.maintenance_window:"true"`