### PR TITLE
Ensure breadcrumbs render in all views.

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -165,6 +165,7 @@
          normalized_date_ssm,
          unitid_ssm,
          parent_ssm,
+         parent_ssim,
          parent_unittitles_ssm,
          ead_ssi,
          ref_ssm,

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -163,4 +163,11 @@ describe "catalog searches", type: :feature, js: true do
       end
     end
   end
+
+  context "when searching within a collection", js: false do
+    it "renders breadcrumbs" do
+      visit "/catalog?f%5Bcollection_sim%5D%5B%5D=Margaret+K.+McElderry+Papers%2C+1900&q=Cats&search_field=all_fields"
+      expect(page).to have_link "Joan Phipson"
+    end
+  end
 end


### PR DESCRIPTION
In certain views the query wasn't including the parent_ssim field, which is necessary to build the breadcrumbs. This fixes tests, will have to replicate it in the Solr repository.

Refs #1153

Solr PR: https://github.com/pulibrary/pul_solr/pull/425