### PR TITLE
Force ArclightHelper to render before PulfalightHelper

### DIFF
--- a/app/helpers/pulfalight_helper.rb
+++ b/app/helpers/pulfalight_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "arclight_helper"
 module PulfalightHelper
+  include ArclightHelper
   # Retrieves the current year
   # @return [Integer]
   def current_year


### PR DESCRIPTION
This should prevent some empty fields from rendering like in https://findingaids.princeton.edu/catalog/C1432_c020?onlineToggle=false

Closes #1438 

Tested and worked in staging.