### PR TITLE
Remove ASpace monitor.

### DIFF
--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -17,9 +17,6 @@ Rails.application.config.after_initialize do
       provider_config.critical = false
     end
     config.add_custom_provider(SolrStatus)
-    config.add_custom_provider(AspaceStatus).configure do |provider_config|
-      provider_config.critical = false
-    end
     config.add_custom_provider(SmtpStatus).configure do |provider_config|
       provider_config.critical = false
     end


### PR DESCRIPTION
We can't do anything about it when we're notified, and we're hammering them in a way they can't handle.