### PR TITLE
Added link to restrictions badge

### DIFF
--- a/app/assets/stylesheets/modules/_document_access_badge.scss
+++ b/app/assets/stylesheets/modules/_document_access_badge.scss
@@ -63,6 +63,9 @@
     color: #8B640E;
     background-color: #FCECBD;
     border-color: #8B640E;
+    & a {
+      color: #8B640E;
+    }
   }
 
   &.restricted {

--- a/app/views/catalog/_restricted_badge.html.erb
+++ b/app/views/catalog/_restricted_badge.html.erb
@@ -4,6 +4,9 @@
       </div>
     <% elsif document.review? %>
       <div class="document-access review">
-        <span class="media-body al-review-icon" aria-hidden="true"><%= blacklight_icon :"icon-review" %></span>Restrictions may apply. See Access Note.
+        <span class="media-body al-review-icon" aria-hidden="true">
+          <%= blacklight_icon :"icon-review" %>
+          </span>
+           <%= link_to("Restrictions may apply. See Access Note.", "#access" )  %>
       </div>
     <% end %>

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -136,6 +136,7 @@ describe "viewing catalog records", type: :feature, js: true do
     it "lets someone click on the access restrictions badge", js: true do
       visit "/catalog/AC136_c2889"
       click_on "Restrictions may apply. See Access Note."
+      expect(page).to have_content("Access & Use")
     end
   end
   context "with a no-digital-content collection show page" do

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -133,7 +133,12 @@ describe "viewing catalog records", type: :feature, js: true do
       expect(page).to have_selector(".document-access.review", text: "Restrictions may apply. See Access Note.")
       expect(page).to have_selector("#component-summary .document-access.restricted", text: "Restricted Content")
     end
-  end
+    it "lets someone click on the access restrictions badge", js: true do 
+      visit "/catalog/AC136_c2889"
+      click_on "Restrictions may apply. See Access Note."
+      byebug
+    end
+   end
   context "with a no-digital-content collection show page" do
     it "doesn't display Has Online Content", js: false do
       visit "/catalog/MC152"

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -133,12 +133,11 @@ describe "viewing catalog records", type: :feature, js: true do
       expect(page).to have_selector(".document-access.review", text: "Restrictions may apply. See Access Note.")
       expect(page).to have_selector("#component-summary .document-access.restricted", text: "Restricted Content")
     end
-    it "lets someone click on the access restrictions badge", js: true do 
+    it "lets someone click on the access restrictions badge", js: true do
       visit "/catalog/AC136_c2889"
       click_on "Restrictions may apply. See Access Note."
-      byebug
     end
-   end
+  end
   context "with a no-digital-content collection show page" do
     it "doesn't display Has Online Content", js: false do
       visit "/catalog/MC152"

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -136,7 +136,9 @@ describe "viewing catalog records", type: :feature, js: true do
     it "lets someone click on the access restrictions badge", js: true do
       visit "/catalog/AC136_c2889"
       click_on "Restrictions may apply. See Access Note."
-      expect(page).to have_content("Access & Use")
+      # most of the access fields are also included on the main collection page
+      # used Location: because it was only showing on this tab
+      expect(page).to have_content("Location:")
     end
   end
   context "with a no-digital-content collection show page" do


### PR DESCRIPTION
<img width="745" alt="Screenshot 2024-11-19 at 9 42 11 AM" src="https://github.com/user-attachments/assets/5c32b65c-19a6-499b-a133-8317058dacc9">


Now the link color is the same @tpendragon I also updated the test.
 
Ref #1368