### PR TITLE
Don't display deprecations in production logs.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,3 +94,10 @@ Rails/SkipsModelValidations:
 Lint/SuppressedException:
   Exclude:
     - 'lib/tasks/performance.rake'
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - development
+    - test
+    - qa
+    - staging

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+Rails.application.config.after_initialize do
+  Deprecation.default_deprecation_behavior = :silence if Rails.env.production?
+end


### PR DESCRIPTION
They're overwhelming our log aggregation.

Closes #1512 