### PR TITLE
Make online content badge clickable

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -174,6 +174,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "geogname_sim", label: "Place", limit: 10
     config.add_facet_field "places_ssim", label: "Places", show: false
     config.add_facet_field "access_subjects_ssim", label: "Subject", limit: 10
+    config.add_facet_field "parent_unittitles_ssim", label: "Series", show: false
 
     # Facet label configuration for links in component show page.
     config.add_facet_field "topics_ssim", label: "Topics", show: false

--- a/app/presenters/online_content_badge.rb
+++ b/app/presenters/online_content_badge.rb
@@ -3,6 +3,7 @@
 class OnlineContentBadge
   include ActionView::Helpers::OutputSafetyHelper
   include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::UrlHelper
 
   attr_reader :document, :icon_only
   def initialize(document, icon_only: false)
@@ -14,8 +15,12 @@ class OnlineContentBadge
     return unless document.has_digital_content?
     if icon_only
       tag.span(icon_span, class: "online-content #{badge_class}", title: label.capitalize)
-    else
+    elsif document.has_direct_digital_content?
       tag.div(children, class: "document-access online-content #{badge_class}")
+    else
+      link_to("/catalog?f[parent_unittitles_ssim][]=#{document['normalized_title_ssm'].first}&f[has_direct_online_content_ssim][]=online") do
+        tag.div(children, class: "document-access online-content #{badge_class}")
+      end
     end
   end
 

--- a/app/views/catalog/_component_summary.html.erb
+++ b/app/views/catalog/_component_summary.html.erb
@@ -7,7 +7,7 @@
           <span><%= document.extent %></span>
         </div>
       <% end %>
-      <%= OnlineContentBadge.new(document).render %>
+      <%= link_to OnlineContentBadge.new(document).render, "/catalog?f[parent_unittitles_ssim][]=#{document["normalized_title_ssm"].first}&f[has_direct_online_content_ssim][]=online" %>
       <%= render partial: "restricted_badge", locals: { document: document, with_link: false } %>
     </div>
   </div>

--- a/app/views/catalog/_component_summary.html.erb
+++ b/app/views/catalog/_component_summary.html.erb
@@ -7,7 +7,7 @@
           <span><%= document.extent %></span>
         </div>
       <% end %>
-      <%= link_to OnlineContentBadge.new(document).render, "/catalog?f[parent_unittitles_ssim][]=#{document["normalized_title_ssm"].first}&f[has_direct_online_content_ssim][]=online" %>
+      <%= OnlineContentBadge.new(document).render %>
       <%= render partial: "restricted_badge", locals: { document: document, with_link: false } %>
     </div>
   </div>

--- a/lib/pulfalight/traject/ead2_component_config.rb
+++ b/lib/pulfalight/traject/ead2_component_config.rb
@@ -132,6 +132,10 @@ to_field "parent_unittitles_teim" do |_record, accumulator, context|
   accumulator.concat context.output_hash["parent_unittitles_ssm"] if context.output_hash["parent_unittitles_ssm"].present?
 end
 
+to_field "parent_unittitles_ssim" do |_record, accumulator, context|
+  accumulator.concat context.output_hash["parent_unittitles_ssm"] if context.output_hash["parent_unittitles_ssm"].present?
+end
+
 to_field "parent_levels_ssm" do |_record, accumulator, context|
   ## Top level document
   parent = settings[:parent] || settings[:root]

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -103,8 +103,8 @@ describe "viewing catalog records", type: :feature, js: true do
       it "renders a place for javascript to enter a viewer" do
         expect(page).to have_css("#readingroom")
       end
-      it "displays 'Has Online content' as a link at the component level" do
-        expect(page).to have_selector("div.document-attributes > a > .document-access.online-content", text: "HAS ONLINE MATERIAL")
+      it "displays 'Has Online Material' at the component level" do
+        expect(page).to have_selector("div.document-attributes > .document-access.online-content", text: "HAS ONLINE MATERIAL")
       end
       it "displays 'Has Online Material' at the collection level" do
         visit "/catalog/MC221"
@@ -116,6 +116,15 @@ describe "viewing catalog records", type: :feature, js: true do
       it "displays 'Has Online Material' in its contents list" do
         visit "/catalog/MC221_c0092"
         expect(page).to have_selector("#component-summary .child-component-table td div.online-direct-content", text: "HAS ONLINE MATERIAL")
+      end
+    end
+
+    context "with a component with children, some of which have online material" do
+      it "lets the user search for online materials" do
+        visit "/catalog/C1491_c3"
+        click_on("SOME ONLINE MATERIAL")
+        expect(page).to have_content "1 entry found"
+        expect(page).to have_content "Box 1, Folder 1"
       end
     end
   end
@@ -314,18 +323,6 @@ describe "viewing catalog records", type: :feature, js: true do
           expect(page).to have_selector "dd.blacklight-odd_ssm", text: /Location of Printed Books Removed for Cataloging/
           expect(page).to have_selector "dd.blacklight-collection_bioghist_ssm", text: /Noël Riley Fitch was born on December 24, 1937/
         end
-      end
-      it "has a toggle switch for showing materials containing online content", js: true do
-        visit "/catalog/C1491"
-        expect(page).to have_content "Working Files, 1955-2018"
-        find(".toggle > span").click
-        expect(page).not_to have_content "Working Files, 1955-2018"
-      end
-      it "lets the user search for online materials", js: true do
-        visit "/catalog/C1491_c1?onlineToggle=false"
-        click_on "SOME ONLINE CONTENT"
-        expect(page).to have_content "1 - 3 of 3 entries"
-        expect(page).to have_content "Box 12, Folder 12"
       end
       it "shows all the relevant notes" do
         visit "/catalog/MC148"

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -315,7 +315,18 @@ describe "viewing catalog records", type: :feature, js: true do
           expect(page).to have_selector "dd.blacklight-collection_bioghist_ssm", text: /Noël Riley Fitch was born on December 24, 1937/
         end
       end
-
+      it "has a toggle switch for showing materials containing online content", js: true do
+        visit "/catalog/C1491"
+        expect(page).to have_content "Working Files, 1955-2018"
+        find(".toggle > span").click
+        expect(page).not_to have_content "Working Files, 1955-2018"
+      end
+      it "lets the user search for online materials", js: true do
+        visit "/catalog/C1491_c1?onlineToggle=false"
+        click_on "SOME ONLINE CONTENT"
+        expect(page).to have_content "1 - 3 of 3 entries"
+        expect(page).to have_content "Box 12, Folder 12"
+      end
       it "shows all the relevant notes" do
         visit "/catalog/MC148"
 

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -103,8 +103,8 @@ describe "viewing catalog records", type: :feature, js: true do
       it "renders a place for javascript to enter a viewer" do
         expect(page).to have_css("#readingroom")
       end
-      it "displays 'Has Online Material' at the component level" do
-        expect(page).to have_selector("div.document-attributes > .document-access.online-content", text: "HAS ONLINE MATERIAL")
+      it "displays 'Has Online content' as a link at the component level" do
+        expect(page).to have_selector("div.document-attributes > a > .document-access.online-content", text: "HAS ONLINE MATERIAL")
       end
       it "displays 'Has Online Material' at the collection level" do
         visit "/catalog/MC221"

--- a/spec/presenters/online_content_badge_spec.rb
+++ b/spec/presenters/online_content_badge_spec.rb
@@ -14,10 +14,19 @@ RSpec.describe OnlineContentBadge do
     end
 
     context "with a document that has indirect online content" do
-      let(:values) { { has_online_content_ssim: ["true"] } }
+      let(:values) do
+        {
+          has_online_content_ssim: ["true"],
+          normalized_title_ssm: ["normalized title"]
+        }
+      end
 
-      it "returns a badge with a some online material label" do
-        expect(badge.render).to include("document-access online-content online-indirect-content", "SOME ONLINE MATERIAL")
+      it "returns a badge with a some online material label and a search link" do
+        expect(badge.render).to include(
+          "document-access online-content online-indirect-content",
+          "SOME ONLINE MATERIAL",
+          "/catalog?f[parent_unittitles_ssim][]=normalized title"
+        )
       end
     end
 


### PR DESCRIPTION
When a user clicks the online content badge, the system performs a search for the online content within that component.

Closes #1521 