### PR TITLE
Change show_presenter to document_presenter to fix deprecation warning

### DIFF
--- a/app/helpers/pulfalight_helper.rb
+++ b/app/helpers/pulfalight_helper.rb
@@ -40,7 +40,7 @@ module PulfalightHelper
   end
 
   def generic_should_render_field?(config_field, document, field)
-    super && show_presenter(document).with_field_group(config_field).field_value(field).present?
+    super && document_presenter(document).with_field_group(config_field).field_value(field).present?
   end
 
   # A DAO for a IIIF manifest has a uri in the role property

--- a/app/views/catalog/_collection_access.html.erb
+++ b/app/views/catalog/_collection_access.html.erb
@@ -1,6 +1,6 @@
 <div class="overview document-info">
   <% metadata = :access_field %>
-  <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+  <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
   <dl>
     <% generic_document_fields(metadata).each do |field_name, field| %>
       <% if generic_should_render_field?(metadata, document, field) %>

--- a/app/views/catalog/_collection_description.html.erb
+++ b/app/views/catalog/_collection_description.html.erb
@@ -1,6 +1,6 @@
 <div class="overview document-info">
   <% metadata = :collection_description_field %>
-  <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+  <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
   <dl>
     <% generic_document_fields(metadata).each do |field_name, field| %>
       <% if generic_should_render_field?(metadata, document, field) %>

--- a/app/views/catalog/_collection_find_more.html.erb
+++ b/app/views/catalog/_collection_find_more.html.erb
@@ -1,6 +1,6 @@
 <div class="overview document-info">
   <% metadata = :indexed_terms_field %>
-  <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+  <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
   <dl>
     <% generic_document_fields(metadata).each do |field_name, field| %>
       <% if generic_should_render_field?(metadata, document, field) %>

--- a/app/views/catalog/_collection_history.html.erb
+++ b/app/views/catalog/_collection_history.html.erb
@@ -1,6 +1,6 @@
 <div class="overview document-info">
   <% metadata = :collection_history_field %>
-  <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+  <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
   <dl>
     <% generic_document_fields(metadata).each do |field_name, field| %>
       <% if generic_should_render_field?(metadata, document, field) %>

--- a/app/views/catalog/_collection_summary_abstract.html.erb
+++ b/app/views/catalog/_collection_summary_abstract.html.erb
@@ -1,7 +1,7 @@
 <dl>
   <dt><h4>Abstract</h4></dt>
   <% metadata = :abstract_field %>
-  <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+  <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
   <% generic_document_fields(metadata).each do |field_name, field| %>
     <% if generic_should_render_field?(metadata, document, field) %>
       <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>

--- a/app/views/catalog/_collection_summary_overview.html.erb
+++ b/app/views/catalog/_collection_summary_overview.html.erb
@@ -1,6 +1,6 @@
 <dl>
   <% metadata = :summary_field %>
-  <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+  <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
   <% generic_document_fields(metadata).each do |field_name, field| %>
     <% if generic_should_render_field?(metadata, document, field) %>
         <%= render partial: "catalog/field", locals: { document: document, field: field, field_name: field_name, metadata: metadata, doc_presenter: doc_presenter } %>

--- a/app/views/catalog/_show_upper_metadata_default.html.erb
+++ b/app/views/catalog/_show_upper_metadata_default.html.erb
@@ -4,7 +4,7 @@
   <dl class="al-metadata-section breadcrumb-item breadcrumb-item-<%= parents.length + 3 %>">
 
     <% blacklight_config.show.component_metadata_partials.each do |metadata| %>
-      <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+      <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
       <% generic_document_fields(metadata).each do |field_name, field| %>
         <% if generic_should_render_field?(metadata, document, field) %>
           <%= render partial: "catalog/field", locals: { document: document, field: field, field_name: field_name, metadata: metadata, doc_presenter: doc_presenter } %>


### PR DESCRIPTION
This eliminates the following deprecation warning: 

```
DEPRECATION WARNING: #show_presenter is deprecated; use #document_presenter instead. (called from generic_should_render_field? at /home/circleci/pulfalight/app/helpers/pulfalight_helper.rb:43)
```