### PR TITLE
Fix search bar deprecation warning

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -15,7 +15,13 @@
         <% end %>
         <div class="row<%= " pb-lg-5 pb-2" if on_home_page? %>">
           <div id="search-navbar" class="search-navbar col-md-9 mx-md-auto" role="search">
-            <%= render Blacklight::SearchBarComponent.new %>
+            <%= render Blacklight::SearchBarComponent.new(
+              url: search_action_url,
+              advanced_search_url: search_action_url(action: 'advanced_search'),
+              params: search_state.params_for_search.except(:qt),
+              search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
+              autocomplete_path: search_action_path(action: :suggest)
+          ) %>
           </div>
         </div>
       </nav>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -15,7 +15,7 @@
         <% end %>
         <div class="row<%= " pb-lg-5 pb-2" if on_home_page? %>">
           <div id="search-navbar" class="search-navbar col-md-9 mx-md-auto" role="search">
-            <%= render_search_bar %>
+            <%= render Blacklight::SearchBarComponent.new %>
           </div>
         </div>
       </nav>

--- a/app/views/shared/_header_navbar_noscript.html.erb
+++ b/app/views/shared/_header_navbar_noscript.html.erb
@@ -10,7 +10,13 @@
     <div class="header__secondary">
       <nav class="container" role="navigation">
         <div id="search-navbar" class="col-xs-12 search-navbar" role="search">
-          <%= render Blacklight::SearchBarComponent.new %>
+          <%= render Blacklight::SearchBarComponent.new(
+              url: search_action_url,
+              advanced_search_url: search_action_url(action: 'advanced_search'),
+              params: search_state.params_for_search.except(:qt),
+              search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
+              autocomplete_path: search_action_path(action: :suggest)
+          ) %>
         </div>
       </nav>
     </div>

--- a/app/views/shared/_header_navbar_noscript.html.erb
+++ b/app/views/shared/_header_navbar_noscript.html.erb
@@ -10,7 +10,7 @@
     <div class="header__secondary">
       <nav class="container" role="navigation">
         <div id="search-navbar" class="col-xs-12 search-navbar" role="search">
-          <%= render_search_bar %>
+          <%= render Blacklight::SearchBarComponent.new %>
         </div>
       </nav>
     </div>


### PR DESCRIPTION
This works in terms of search but breaks some styling on the size of the search box on the main page. Not ready to merge.

<img width="1719" alt="Screenshot 2025-03-21 at 10 11 47 AM" src="https://github.com/user-attachments/assets/14576fe9-a800-466e-8d30-27c710e4843e" />


Fixes this deprecation warning: 

> DEPRECATION WARNING: render_search_bar is deprecated and will be removed from a future release (Call `render Blacklight::SearchBarComponent.new' instead). (called from _app_views_shared__header_navbar_noscript_html_erb___1724450134216805659_66020 at /home/circleci/pulfalight/app/views/shared/_header_navbar_noscript.html.erb:13)

See also this PR: https://github.com/projectblacklight/blacklight/pull/2715/files