### PR TITLE
Improve date range situation.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
  *
  *= require_self
  *= require 'arclight'
+ *= require 'blacklight_range_limit'
 */
 @import 'overrides';
 @import 'blacklight';
@@ -32,5 +33,4 @@
 @import 'layouts/home';
 @import 'layouts/catalog_show';
 @import 'layouts/collection_show';
-@import 'blacklight_range_limit';
 @import 'jstree-theme';


### PR DESCRIPTION
This doesn't get the bars to render in the default display, but in "View Larger" and after faceting, it does work.

I couldn't figure out what's going on with the default view, but this is significantly better and we can improve the situation later when we update ArcLight and are able to use the new Blacklight Range Limit that doesn't use ChartJS.

Closes #1516