### PR TITLE
Add an "online' column to contents list

### DIFF
--- a/app/javascript/components/ChildTable.vue
+++ b/app/javascript/components/ChildTable.vue
@@ -51,6 +51,7 @@ export default {
     return {
       "columns": [
         { 'name': 'id', 'display_name': 'Select Items', 'align': 'center', 'checkbox': true },
+        { 'name': 'online', 'display_name': 'Online', 'align': 'center', 'raw': true},
         { 'name': 'title', 'display_name': 'Title', 'align': 'center', 'sortable': true },
         { 'name': 'date', 'sortable': true },
         { 'name': 'container', 'display_name': 'Container', 'sortable': true }

--- a/app/javascript/components/PulfaDataTable.vue
+++ b/app/javascript/components/PulfaDataTable.vue
@@ -65,6 +65,8 @@
             </add-to-cart-button>
           </div>
 
+          <div v-else-if="col.raw" v-html="lineItem[col.name].value" ></div>
+
           <span v-else>
             <lux-hyperlink v-if="lineItem[col.name].link" :href="lineItem[col.name].link">
               {{ lineItem[col.name].value }}

--- a/app/services/child_table_builder.rb
+++ b/app/services/child_table_builder.rb
@@ -24,6 +24,7 @@ class ChildTableBuilder
         value: Array.wrap(document.title).join(", "),
         link: Rails.application.routes.url_helpers.solr_document_url(id: document.id)
       },
+      online: OnlineContentBadge.new(document).render,
       date: Array.wrap(document.date_created).join(", "),
       container: Array.wrap(document.container).join(", "),
       form_params: document.aeon_request.form_attributes,

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -119,7 +119,15 @@ describe "viewing catalog records", type: :feature, js: true do
         expect(page).to have_selector "li#MC221_c0094 .online-direct-content"
       end
     end
+
+    context "which has children with online material", js: true do
+      it "displays 'Has Online Material' in its contents list" do
+        visit "/catalog/MC221_c0092"
+        expect(page).to have_selector("#component-summary .child-component-table td div.online-direct-content", text: "HAS ONLINE MATERIAL")
+      end
+    end
   end
+
   context "when given something with access restrictions", js: false do
     it "displays 'Restricted' at the collection level" do
       visit "/catalog/C0187"


### PR DESCRIPTION
For consideration, this is the simplest implementation to satisfy #1523. It results in a small footprint for the badge and maximal context for its meaning.

![Screenshot 2025-05-05 at 11 41 44 AM](https://github.com/user-attachments/assets/f7eb3fc2-522c-4b51-98aa-336bdedcd0b4)
