### PR TITLE
Remove unneeded toc code

### DIFF
--- a/app/javascript/pulfalight/toc.es6
+++ b/app/javascript/pulfalight/toc.es6
@@ -5,11 +5,6 @@ export default class TocBuilder {
     // have the correct selected node id. The toc element itself is permanent (not
     // updated by turbolinks), and is instead updated by event-triggered javascript.
     this.dataElement = $(`${element}-data`)
-
-    // Setup the initial online toggle value if it's missing
-    if (this.getOnlineToggleValue() === null) {
-      this.getOnlineToggleValue('false')
-    }
   }
 
   get expanded() {


### PR DESCRIPTION
https://github.com/pulibrary/pulfalight/blob/main/app/javascript/pulfalight/toc.es6#L11

This code is not needed as a null value for `pulfalightOnlineToggle` is equivalent to false. And also, this code has a bug so doesn't do anything anyway.

https://github.com/pulibrary/pulfalight/blob/main/app/javascript/pulfalight/toc.es6#L51-L54