### PR TITLE
Remove code that was accidentally re-introduced

### DIFF
--- a/app/presenters/summary_storage_note_presenter.rb
+++ b/app/presenters/summary_storage_note_presenter.rb
@@ -53,13 +53,6 @@ class SummaryStorageNotePresenter
     list = make_nested_locations_list(notes)
     # add text notes to list of locations
     append_to_list(list, text_notes)
-  rescue JSON::ParserError
-    processed_notes = process_summary_notes(notes)
-    content_tag(:ul) do
-      processed_notes.map do |note|
-        concat(content_tag(:li, note))
-      end
-    end
   end
 
   private


### PR DESCRIPTION
Code removed in #1591 was re-introduced in #1588 and references a method
that no longer exists.

This code was hit in staging, probably due to a stale index (the same record did not error in a after deploying main). A full
reindex is underway on staging.
