### PR TITLE
reject requests that contain file uploads

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative "boot"
+require_relative "../lib/pulfalight/middleware/no_file_uploads"
 
 require "rails/all"
 require_relative "lando_env"

--- a/lib/pulfalight/middleware/no_file_uploads.rb
+++ b/lib/pulfalight/middleware/no_file_uploads.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Pulfalight
+  module Middleware
+    # This class is responsible for ensuring that users cannot upload temporary files
+    # to the server as part of a multipart/form-data request.
+    #
+    # While these uploaded files are deleted immediately as part of the request cycle
+    # and are not placed in a directory where they can do much harm, they can still
+    # trip OIT's malicious files sensors and then they take the server off the network.
+    #
+    # Since we have no need for these files, we reject them.
+    class NoFileUploads
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env['rack.multipart.tempfile_factory'] = lambda { |_filename, _content_type|
+          raise 'Sorry, the findingaids does not support file uploads'
+        }
+        app.call env
+      end
+
+        private
+
+          attr_reader :app
+    end
+  end
+end
+

--- a/lib/pulfalight/middleware/no_file_uploads.rb
+++ b/lib/pulfalight/middleware/no_file_uploads.rb
@@ -15,16 +15,15 @@ module Pulfalight
       end
 
       def call(env)
-        env['rack.multipart.tempfile_factory'] = lambda { |_filename, _content_type|
-          raise 'Sorry, the findingaids does not support file uploads'
+        env["rack.multipart.tempfile_factory"] = lambda { |_filename, _content_type|
+          raise "Sorry, the findingaids does not support file uploads"
         }
         app.call env
       end
 
         private
 
-          attr_reader :app
+      attr_reader :app
     end
   end
 end
-

--- a/lib/pulfalight/middleware/no_file_uploads_spec.rb
+++ b/lib/pulfalight/middleware/no_file_uploads_spec.rb
@@ -1,22 +1,21 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 describe Pulfalight::Middleware::NoFileUploads, type: :request do
-  it 'does not create a tempfile when the user does a multipart/form-data request' do
+  it "does not create a tempfile when the user does a multipart/form-data request" do
     allow(Tempfile).to receive(:new).and_call_original
     mock_upload = Rack::Test::UploadedFile.new(
       StringIO.new("<?php echo 'codeb0ss:'; echo '<pre>' . shell_exec($_GET['cmd']) . '</pre>'; ?>"),
-      'Application/php',
+      "Application/php",
       false, # not a binary file
-      original_filename: 'bad.php'
+      original_filename: "bad.php"
     )
 
     expect do
-      post '/feedback', params: { feedback_form: { name: mock_upload } }, headers: { 'Content-Type' => 'multipart/form-data' }
-    end.to raise_error 'Sorry, the findingaids does not support file uploads'
+      post "/feedback", params: { feedback_form: { name: mock_upload } }, headers: { "Content-Type" => "multipart/form-data" }
+    end.to raise_error "Sorry, the findingaids does not support file uploads"
 
     expect(Tempfile).not_to have_received(:new)
   end
 end
-

--- a/lib/pulfalight/middleware/no_file_uploads_spec.rb
+++ b/lib/pulfalight/middleware/no_file_uploads_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Pulfalight::Middleware::NoFileUploads, type: :request do
+  it 'does not create a tempfile when the user does a multipart/form-data request' do
+    allow(Tempfile).to receive(:new).and_call_original
+    mock_upload = Rack::Test::UploadedFile.new(
+      StringIO.new("<?php echo 'codeb0ss:'; echo '<pre>' . shell_exec($_GET['cmd']) . '</pre>'; ?>"),
+      'Application/php',
+      false, # not a binary file
+      original_filename: 'bad.php'
+    )
+
+    expect do
+      post '/feedback', params: { feedback_form: { name: mock_upload } }, headers: { 'Content-Type' => 'multipart/form-data' }
+    end.to raise_error 'Sorry, the findingaids does not support file uploads'
+
+    expect(Tempfile).not_to have_received(:new)
+  end
+end
+


### PR DESCRIPTION
part of OIT security theater and a yank and paste of

https://github.com/pulibrary/orangelight/pull/5128

the PR rejects any attempt to upload files

related to https://princeton.service-now.com/service?sys_id=d878ef12876f6e907f147487cebb35ad&view=sp&id=ticket&table=incident
