### PR TITLE
Ensure asdf Ruby version matches CI and production

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.2.6
+ruby 3.2.8
 nodejs 22.10.0
 yarn 1.22.10


### PR DESCRIPTION
There was a concern that rubocop didn't run correctly on 3.2.8, but it was probably a local setup issue:

<img width="1488" height="398" alt="image" src="https://github.com/user-attachments/assets/e2ab6a95-cbf2-484b-86ac-187ea70e4cb3" />
