### PR TITLE
[smtp relay] use the new smtp relay

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,5 +95,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST", "pulfalight.princeton.edu"), protocol: ENV.fetch("APPLICATION_HOST_PROTOCOL", "https") }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: "lib-ponyexpr.princeton.edu", enable_starttls: false }
+  config.action_mailer.smtp_settings = { address: "lib-ponyexpr-prod.princeton.edu", enable_starttls: false }
 end


### PR DESCRIPTION
related to this ticket https://gitlab.lib.princeton.edu/ops/team-handbook/-/issues/265

we have a new relay that works with proofpoint that is the preferred way
of deliverying [princeton.edu email](https://oit.princeton.edu/events/smtp-email-retirement-personal-and-service-accounts)
