### PR TITLE
Fix truncated access restriction links

### DIFF
--- a/app/assets/stylesheets/modules/_accessrestrict_notice.scss
+++ b/app/assets/stylesheets/modules/_accessrestrict_notice.scss
@@ -10,6 +10,7 @@
     background-color: #fdf1f1;
     border: none;
     border-left: 1rem solid #f19b99;
+    margin-top: 1.5rem;
 }
 
 #restrictionsModal h1 {
@@ -20,4 +21,5 @@
     background-color: #FCECBD;
     border: none;
     border-left: 1rem solid #8B640E;
+    margin-top: 1.5rem;
 }

--- a/app/views/catalog/_restriction_warning.html.erb
+++ b/app/views/catalog/_restriction_warning.html.erb
@@ -1,12 +1,14 @@
 <%- # If we have a combined field with headings, use it. %>
 <% if field_name == "accessrestrict_ssm" %>
   <% document.field_with_headings(field_name).each do |field_key, field_value| %>
-    <% if (field_value.join.length <= 300) %>
+    <!-- Get visible text, strip html tags -->
+    <% visible_text = strip_tags(field_value.join(" ")) %>
+    <% if visible_text.length <= 300 %>
+      <!-- render full notice with html/link -->
       <%= paragraph_separator(value: field_value.map(&:html_safe))%>
     <% else %>
-      <%= 
-        truncate(field_value.join(' '.html_safe), length: 300)
-      %> 
+      <!-- render text with no html; modal has full text and link -->
+      <%= truncate(visible_text, length: 300) %>
       <br/>
       <button id="restrictionsModal-trigger-link" type="button" class="btn btn-link" data-toggle="modal" data-target="#restrictionsModal">
         Read full Conditions Governing Access

--- a/spec/views/catalog/_restriction_warning.html.erb_spec.rb
+++ b/spec/views/catalog/_restriction_warning.html.erb_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "catalog/_restriction_warning" do
+  before(:all) do
+    ActionView::TestCase::TestController.include(Arclight::FieldConfigHelpers)
+  end
+
+  let(:html_link) do
+    '<a href="https://library.princeton.edu/special-collections/policies/' \
+      'access-to-restricted-collections">Access to Restricted Collections policy</a>'
+  end
+  let(:solr_document) do
+    SolrDocument.new("id" => "C1491_c1")
+  end
+  let(:locals) do
+    { document: solr_document, field: nil, field_name: "accessrestrict_ssm", metadata: nil, doc_presenter: nil }
+  end
+
+  before do
+    allow(solr_document).to receive(:field_with_headings).with("accessrestrict_ssm").and_return(headings)
+  end
+
+  context "when the restriction text contains HTML and visible text exceeds 300 chars" do
+    let(:body) { "Restricted access. " * 20 }
+    let(:headings) do
+      # As raw html this message has 543 characters.
+      # As visible text, the message has 437 characters and will be truncated.
+      { "Conditions Governing Access" => ["#{body} See #{html_link} for details."] }
+    end
+
+    it "renders a truncated plain-text preview with no escaped HTML" do
+      render partial: "catalog/restriction_warning", locals: locals
+
+      expect(rendered).to have_button("Read full Conditions Governing Access")
+      expect(rendered).not_to include("&lt;a ")
+      expect(rendered).not_to include("<a href=\"https://library.princeton.edu")
+    end
+
+    it "shows the full HTML with a working link inside the modal" do
+      render partial: "catalog/restriction_warning", locals: locals
+      modal = view.content_for(:modals)
+
+      expect(modal).to have_css(
+        "#restrictionsModal .modal-body a[href*='access-to-restricted-collections']",
+        text: "Access to Restricted Collections policy"
+      )
+    end
+  end
+
+  context "when the visible restriction text is short but contains HTML with a long URL" do
+    let(:body) { "Restricted access. " * 10 }
+    let(:headings) do
+      # As raw html this message has 353 characters.
+      # As visible text, the message has 190.
+      { "Conditions Governing Access" => ["#{body} See #{html_link} for details."] }
+    end
+
+    it "renders the full HTML link without truncating or escaping" do
+      render partial: "catalog/restriction_warning", locals: locals
+
+      expect(rendered).not_to have_button("Read full Conditions Governing Access")
+      expect(rendered).to have_css(
+        "a[href*='access-to-restricted-collections']",
+        text: "Access to Restricted Collections policy"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Closes #1637

- **Fix truncated access restriction links**
- **Fix spacing below download button**

https://findingaids-qa.princeton.edu/catalog/C1491_c4216

Before:
<img width="918" height="414" alt="Screenshot 2026-04-21 at 12 26 49 PM" src="https://github.com/user-attachments/assets/30518230-7ee1-4670-91a3-3a02b0425d3d" />

After:
<img width="911" height="405" alt="Screenshot 2026-04-21 at 12 29 17 PM" src="https://github.com/user-attachments/assets/80f02caa-251a-4349-afe7-7f1dd784efd7" />

