### PR TITLE
Temporary banner for Aeon upgrade on 5/12.

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,12 @@
 <header class="lux">
+  <lux-banner>
+    <p>
+      <lux-icon-base width="16" height="16" icon-name="alert" icon-color="red">
+        <lux-icon-alert></lux-icon-alert>
+      </lux-icon-base>
+      We are updating the request system for Special Collections materials. Users will be unable to request new materials for their Special Collections Research Accounts via the library catalog and finding aids database on Tuesday, May 12 from 9pm-Midnight.
+    </p>
+  </lux-banner>
   <lux-library-header app-name="<%= application_name %>" app-url="<%= root_path %>" max-width="1400">
       <div class="cart-view-toggle-block">
         <cart-view-toggle></cart-view-toggle>


### PR DESCRIPTION
For display from the morning off 5/12. Can be taken down once the Aeon upgrade is confirmed concluded and successful. 