### PR TITLE
Revert "Temporary banner for Aeon upgrade on 5/12."

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,12 +1,4 @@
 <header class="lux">
-  <lux-banner>
-    <p>
-      <lux-icon-base width="16" height="16" icon-name="alert" icon-color="red">
-        <lux-icon-alert></lux-icon-alert>
-      </lux-icon-base>
-      We are updating the request system for Special Collections materials. Users will be unable to request new materials for their Special Collections Research Accounts via the library catalog and finding aids database on Tuesday, May 12 from 9pm-Midnight.
-    </p>
-  </lux-banner>
   <lux-library-header app-name="<%= application_name %>" app-url="<%= root_path %>" max-width="1400">
       <div class="cart-view-toggle-block">
         <cart-view-toggle></cart-view-toggle>


### PR DESCRIPTION
Reverts pulibrary/pulfalight#1670. Upgrade has concluded successfully, requesting from pulfa and the catalog have been tested successfully. We can take the banner down. 