### PR TITLE
Add quotes around interpolated password in config.yml

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -2,7 +2,7 @@ defaults: &defaults
   external_universal_viewer_url: "https://figgy.princeton.edu/viewer"
   archivespace_url: <%= ENV["ASPACE_URL"] || "https://aspace.princeton.edu/staff/api" %>
   archivespace_user: <%= ENV["ASPACE_USER"] %>
-  archivespace_password: <%= ENV["ASPACE_PASSWORD"] %>
+  archivespace_password: '<%= ENV["ASPACE_PASSWORD"] %>'
   # aeon_url: 'https://lib-aeon.princeton.edu/aeon/Aeon.dll'
   aeon_url: 'https://princeton.aeon.atlas-sys.com/logon'
   unpublished_auth_token: <%= ENV["UNPUBLISHED_AUTH_TOKEN"] %>


### PR DESCRIPTION
There is a chance that an ASpace password could include special characters, and should therefore be put in quotes when it is interpolated into a YAML file.

Closes #1691