### PR TITLE
[#1635] Make parent components sticky when navigating the ToC

### DIFF
--- a/app/javascript/pulfalight/toc.es6
+++ b/app/javascript/pulfalight/toc.es6
@@ -62,6 +62,7 @@ export default class TocBuilder {
       this.setupTree()
       this.setupToggleElement()
       this.setupEventHandlers()
+      this.setupObservers()
     }
   }
 
@@ -88,6 +89,8 @@ export default class TocBuilder {
       const selectedElement = $(`#${selectedId}`)
       if (selectedElement.length > 0) {
         this.#scrollComponentToTop(selectedElement)
+        // Make the parent element sticky so the user knows the context of the element
+        selectedElement.get().forEach(element => this.#makeParentSticky(element))
       }
     })
     this.toggleElement.addEventListener('change', (e) => {
@@ -102,6 +105,26 @@ export default class TocBuilder {
         this.build()
       }
     })
+  }
+
+  setupObservers() {
+    function addObservers() {
+      document.querySelectorAll('.jstree-leaf').forEach(leaf => observer.observe(leaf))
+    }
+
+    const scrollport = document.querySelector('#toc');
+    const observer = new IntersectionObserver(
+      entries => entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          this.#makeParentSticky(entry.target)
+        }
+      }),
+      { root: scrollport, threshold: 0.5 }
+    );
+
+    document.querySelectorAll('.jstree-leaf').forEach(leaf => observer.observe(leaf))
+    addObservers()
+    $("#toc").on("open_node.jstree", elements => addObservers())
   }
 
   setupTree() {
@@ -139,7 +162,18 @@ export default class TocBuilder {
     // Note: a larger scrollDistance means that the scrollport has scrolled
     // a greater distance from the initial position (i.e. the componentElement
     // will appear closer to the top of the screen)
-    const scrollDistance = component.offsetTop - firstComponent.offsetTop
+    const scrollDistance = component.offsetTop - firstComponent.offsetTop - (this.#parentComponentLink(component)?.offsetHeight || 0)
     scrollBox.scrollTop = scrollDistance
+  }
+
+  #makeParentSticky(element) {
+    this.#parentComponentLink(element)?.classList?.add('sticky-top')
+  }
+
+  #parentComponentLink(element) {
+    return element
+      .closest('ul')
+      ?.closest('li')
+      ?.querySelector('a')
   }
 }

--- a/spec/features/toc_spec.rb
+++ b/spec/features/toc_spec.rb
@@ -92,7 +92,11 @@ describe "Table of Contents", type: :feature, js: true do
   end
 
   describe "components with many child components" do
+    def child_near_top = "C1643_c3"
     def child_near_bottom = "C1643_c92"
+    def parent_selector = "#C1643_c2_anchor"
+    def other_parent_selector = "#C1643_c369"
+
     it "scrolls the child component into the scrollport", js: true do
       visit "/catalog/#{child_near_bottom}"
       expect("##{child_near_bottom}").to be_within_toc_scrollport
@@ -102,6 +106,28 @@ describe "Table of Contents", type: :feature, js: true do
       page.current_window.resize_to 972, 972
       visit "/catalog/#{child_near_bottom}"
       expect("##{child_near_bottom}").to be_within_toc_scrollport
+    end
+
+    it "shows the parent element of the selected child component", js: true do
+      visit "/catalog/#{child_near_bottom}"
+      expect(parent_selector).to be_within_toc_scrollport
+    end
+
+    it "does not show other components that are not the parent", js: true do
+      visit "/catalog/#{child_near_bottom}"
+      expect(other_parent_selector).not_to be_within_toc_scrollport
+    end
+
+    it "shows the parent element of the selected child component", js: true do
+      visit "/catalog/#{child_near_top}"
+      expect("##{child_near_top}").to be_within_toc_scrollport
+      expect("##{child_near_bottom}").not_to be_within_toc_scrollport
+      expect(parent_selector).to be_within_toc_scrollport
+
+      execute_script "document.querySelector('##{child_near_bottom}').scrollIntoView()"
+      expect("##{child_near_top}").not_to be_within_toc_scrollport
+      expect("##{child_near_bottom}").to be_within_toc_scrollport
+      expect(parent_selector).to be_within_toc_scrollport
     end
   end
 


### PR DESCRIPTION
Add IntersectionObservers to each TOC leaf entry.  When one of the observers notices that it is displaying withing the ToC, it makes its parent's link sticky using the existing `.sticky-top` class.
