### PR TITLE
When the focus is in the cart pressing escape should close the cart

### DIFF
--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -1,9 +1,8 @@
 <template>
 
   <transition name="slide">
-
-  <div v-if="isVisible" :class="['request-cart']">
-
+    <dialog ref="dialog" class="request-cart">
+  
     <div class="panel">
       <table :class="['lux-data-table', 'fixed-header']">
 
@@ -164,8 +163,10 @@
       </div>
     </form>
 
-  </div>
+
+  </dialog>
   </transition>
+  
 </template>
 
 <script>
@@ -215,16 +216,27 @@ export default {
       }
     }
   },
-  watch: {
-    isVisible(newIsVisible, oldIsVisible) {
-      if(newIsVisible){
-          this.$nextTick(()=>{
-            this.$refs.closeCart.$el.focus()
-          })
+
+  created() {
+    this.$store.subscribe((mutation, state) => {
+      console.log(mutation.type)
+      console.log(mutation.payload)
+      if (mutation.type === "TOGGLE_VISIBILITY") {
+        if (this.$refs.dialog.open) {
+          this.$refs.dialog.close()
+        } else {
+          this.openDialog()
+        }
       }
-    },
+    })
   },
   methods: {
+    openDialog() {
+      this.$nextTick(()=>{
+          this.$refs.dialog.showModal()
+          this.$refs.closeCart.$el.focus()
+      })
+    },
     displayContainers(containers) {
       let displayString = containers.map(function(container) {
         let value = 'Unspecified'
@@ -480,10 +492,7 @@ export default {
 }
 /* Component Styling */
 .request-cart {
-  /* Custom */
-  position: fixed;
-  z-index: 2020;
-  display: block;
+  
   top: 20%;
   height: 80%;
   right: 0;

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -1,7 +1,7 @@
 <template>
 
   <transition name="slide">
-    <dialog ref="dialog" class="request-cart" @close="syncVisibilityAfterNativeClose">
+    <dialog ref="dialog" class="request-cart" @close="syncVisibilityAfterNativeClose" @click="handleDialogClick">
   
     <div class="panel">
       <table :class="['lux-data-table', 'fixed-header']">
@@ -231,6 +231,12 @@ export default {
     }
   },
   methods: {
+    handleDialogClick(event) {
+      console.log("handleDialogClick", event.target, this.$refs.dialog)
+      if (event.target === this.$refs.dialog) {
+        this.toggleCartView()
+      }
+    },
     syncVisibilityAfterNativeClose() {
       if (this.$store.state.cart.isVisible && !this.$refs.dialog.open) {
         this.$store.commit("TOGGLE_VISIBILITY")

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -1,7 +1,7 @@
 <template>
 
   <transition name="slide">
-    <dialog ref="dialog" class="request-cart">
+    <dialog ref="dialog" class="request-cart" @close="syncVisibilityAfterNativeClose">
   
     <div class="panel">
       <table :class="['lux-data-table', 'fixed-header']">
@@ -162,8 +162,6 @@
         <input name="Notes" type="hidden" :value="note" />
       </div>
     </form>
-
-
   </dialog>
   </transition>
   
@@ -216,24 +214,27 @@ export default {
       }
     }
   },
-
-  created() {
-    this.$store.subscribe((mutation, state) => {
-      if (mutation.type === "TOGGLE_VISIBILITY") {
-        if (this.$refs.dialog.open) {
-          this.$refs.dialog.close()
-        } else {
-          this.openDialog()
+  watch: {
+    isVisible(newIsVisible, oldIsVisible) {
+      const dialog = this.$refs.dialog
+	
+      if (newIsVisible) {
+        if (!dialog.open) {
+          dialog.showModal()
         }
+        this.$nextTick(() => {
+          this.$refs.closeCart?.$el?.focus?.()
+        })
+      } else if (dialog.open) {
+        dialog.close()
       }
-    })
+    }
   },
   methods: {
-    openDialog() {
-      this.$nextTick(()=>{
-          this.$refs.dialog.showModal()
-          this.$refs.closeCart.$el.focus()
-      })
+    syncVisibilityAfterNativeClose() {
+      if (this.$store.state.cart.isVisible && !this.$refs.dialog.open) {
+        this.$store.commit("TOGGLE_VISIBILITY")
+      }
     },
     displayContainers(containers) {
       let displayString = containers.map(function(container) {

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -219,8 +219,6 @@ export default {
 
   created() {
     this.$store.subscribe((mutation, state) => {
-      console.log(mutation.type)
-      console.log(mutation.payload)
       if (mutation.type === "TOGGLE_VISIBILITY") {
         if (this.$refs.dialog.open) {
           this.$refs.dialog.close()
@@ -492,10 +490,12 @@ export default {
 }
 /* Component Styling */
 .request-cart {
-  
+  position: fixed;
   top: 20%;
   height: 80%;
   right: 0;
+  left: auto;
+  margin: 0;
   background-color: #ffffff;
   border: 1px solid #8f8f8f;
   width: 40%;

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -207,6 +207,7 @@ export default {
     },
     isVisible: {
       get() {
+        console.log("isVisible", this.$store.state.cart.isVisible)
         return this.$store.state.cart.isVisible
       },
       set() {
@@ -217,9 +218,15 @@ export default {
   watch: {
     isVisible(newIsVisible, oldIsVisible) {
       const dialog = this.$refs.dialog
-	
+      console.log('=================')
+	console.log(dialog)
       if (newIsVisible) {
+        console.log('========++++++++++++=========')
+        console.log(newIsVisible)
+        console.log('========+++###++=========')
         if (!dialog.open) {
+           console.log('========+++++dialog.showModal+++++++=========')
+           console.log(dialog.showModal)
           dialog.showModal()
         }
         this.$nextTick(() => {
@@ -266,6 +273,7 @@ export default {
       this.$store.dispatch("removeItemFromCart", item)
     },
     toggleCartView(event) {
+      console.log("togglecartview event", event)
       this.$store.commit("TOGGLE_VISIBILITY")
     },
     clearForm() {

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -207,7 +207,6 @@ export default {
     },
     isVisible: {
       get() {
-        console.log("isVisible", this.$store.state.cart.isVisible)
         return this.$store.state.cart.isVisible
       },
       set() {
@@ -218,15 +217,8 @@ export default {
   watch: {
     isVisible(newIsVisible, oldIsVisible) {
       const dialog = this.$refs.dialog
-      console.log('=================')
-	console.log(dialog)
       if (newIsVisible) {
-        console.log('========++++++++++++=========')
-        console.log(newIsVisible)
-        console.log('========+++###++=========')
         if (!dialog.open) {
-           console.log('========+++++dialog.showModal+++++++=========')
-           console.log(dialog.showModal)
           dialog.showModal()
         }
         this.$nextTick(() => {
@@ -239,7 +231,6 @@ export default {
   },
   methods: {
     handleDialogClick(event) {
-      console.log("handleDialogClick", event.target, this.$refs.dialog)
       if (event.target === this.$refs.dialog) {
         this.toggleCartView()
       }

--- a/app/javascript/test/requestCart.spec.js
+++ b/app/javascript/test/requestCart.spec.js
@@ -5,6 +5,7 @@ import { store } from '@/store/index.es6'
 import { createStore } from 'vuex'
 import { LuxInputButton, LuxInputText } from 'lux-design-system'
 import { nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 
 describe('RequestCart.vue', () => {
   test('Rendering locations', async () => {
@@ -200,9 +201,6 @@ describe('RequestCart.vue', () => {
     expect(container.querySelector('.request-cart[open]')).toBe(null)
   })
   test('click outside of the cart closes the cart', async () => {
-    const htmlDialog = HTMLDialogElement.prototype
-    
-
     const customStore = {
       modules: {
         cart: {
@@ -231,15 +229,13 @@ describe('RequestCart.vue', () => {
         }
       }
     })
-    const cart = container.querySelector('.request-cart')
-    expect(cart).not.toBe(null)
+    expect(container.querySelector('.request-cart[open]')).toBeFalsy()
     
     mergedStore.commit('TOGGLE_VISIBILITY')
-    await nextTick()
-    expect(container.querySelector('.request-cart[open]')).toBe(true)
+    await flushPromises()
+    expect(container.querySelector('.request-cart[open]')).toBeTruthy()
     
     await fireEvent.click(container.querySelector('dialog'))
-    await nextTick()
-    expect(container.querySelector('.request-cart[open]')).toBe(null)
+    expect(container.querySelector('.request-cart[open]')).toBeFalsy()
   })
 })

--- a/app/javascript/test/requestCart.spec.js
+++ b/app/javascript/test/requestCart.spec.js
@@ -164,4 +164,39 @@ describe('RequestCart.vue', () => {
     const button = container.querySelector("button[type='submit']")
     expect(button.textContent.trim()).toBe('No Items in Your Cart')
   })
+  test('pressing escape closes the cart', async () => {
+    const customStore = {
+      modules: {
+        cart: {
+          state: {
+            items: [],
+            isVisible: true
+          },
+          actions: cartActions,
+          mutations: cartMutations
+        }
+      }
+    }
+    const mergedStore = createStore({ ...store, ...customStore })
+    const { container } = render(RequestCart, {
+      global: {
+        plugins: [mergedStore],
+        components: {
+          'lux-input-button': LuxInputButton,
+          'lux-input-text': LuxInputText
+        }
+      },
+      props: {
+        configuration: {},
+        globalFormParams: {
+          SystemID: 'Pulfa'
+        }
+      }
+    })
+    const cart = container.querySelector('.request-cart')
+    expect(cart).not.toBe(null)
+    await fireEvent.keyDown(cart, { key: 'Escape' })
+    expect(mergedStore.state.cart.isVisible).toBe(false)
+    expect(container.querySelector('.request-cart')).toBe(null)
+  })
 })

--- a/app/javascript/test/requestCart.spec.js
+++ b/app/javascript/test/requestCart.spec.js
@@ -4,6 +4,7 @@ import { render, fireEvent } from '@testing-library/vue'
 import { store } from '@/store/index.es6'
 import { createStore } from 'vuex'
 import { LuxInputButton, LuxInputText } from 'lux-design-system'
+import { nextTick } from 'vue'
 
 describe('RequestCart.vue', () => {
   test('Rendering locations', async () => {
@@ -196,6 +197,49 @@ describe('RequestCart.vue', () => {
     const cart = container.querySelector('.request-cart')
     expect(cart).not.toBe(null)
     await fireEvent.keyDown(cart, { key: 'Escape' })
+    expect(container.querySelector('.request-cart[open]')).toBe(null)
+  })
+  test('click outside of the cart closes the cart', async () => {
+    const htmlDialog = HTMLDialogElement.prototype
+    
+
+    const customStore = {
+      modules: {
+        cart: {
+          state: {
+            items: [],
+            isVisible: false
+          },
+          actions: cartActions,
+          mutations: cartMutations
+        }
+      }
+    }
+    const mergedStore = createStore({ ...store, ...customStore })
+    const { container } = render(RequestCart, {
+      global: {
+        plugins: [mergedStore],
+        components: {
+          'lux-input-button': LuxInputButton,
+          'lux-input-text': LuxInputText
+        }
+      },
+      props: {
+        configuration: {},
+        globalFormParams: {
+          SystemID: 'Pulfa'
+        }
+      }
+    })
+    const cart = container.querySelector('.request-cart')
+    expect(cart).not.toBe(null)
+    
+    mergedStore.commit('TOGGLE_VISIBILITY')
+    await nextTick()
+    expect(container.querySelector('.request-cart[open]')).toBe(true)
+    
+    await fireEvent.click(container.querySelector('dialog'))
+    await nextTick()
     expect(container.querySelector('.request-cart[open]')).toBe(null)
   })
 })

--- a/app/javascript/test/requestCart.spec.js
+++ b/app/javascript/test/requestCart.spec.js
@@ -4,7 +4,6 @@ import { render, fireEvent } from '@testing-library/vue'
 import { store } from '@/store/index.es6'
 import { createStore } from 'vuex'
 import { LuxInputButton, LuxInputText } from 'lux-design-system'
-import { nextTick } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 
 describe('RequestCart.vue', () => {
@@ -230,11 +229,11 @@ describe('RequestCart.vue', () => {
       }
     })
     expect(container.querySelector('.request-cart[open]')).toBeFalsy()
-    
+
     mergedStore.commit('TOGGLE_VISIBILITY')
     await flushPromises()
     expect(container.querySelector('.request-cart[open]')).toBeTruthy()
-    
+
     await fireEvent.click(container.querySelector('dialog'))
     expect(container.querySelector('.request-cart[open]')).toBeFalsy()
   })

--- a/app/javascript/test/requestCart.spec.js
+++ b/app/javascript/test/requestCart.spec.js
@@ -196,7 +196,6 @@ describe('RequestCart.vue', () => {
     const cart = container.querySelector('.request-cart')
     expect(cart).not.toBe(null)
     await fireEvent.keyDown(cart, { key: 'Escape' })
-    expect(mergedStore.state.cart.isVisible).toBe(false)
-    expect(container.querySelector('.request-cart')).toBe(null)
+    expect(container.querySelector('.request-cart[open]')).toBe(null)
   })
 })

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -132,7 +132,7 @@ describe "accessibility", type: :feature, js: true do
 
       # Click request button and wait for request cart div
       find(".add-to-cart-block").click
-      expect(page).to have_css("div.request-cart")
+      expect(page).to have_css("div dialog.request-cart")
 
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)


### PR DESCRIPTION
related to #505

This PR adds native [HTMLDialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) element in the RequestCart template. Dialog supports the Escape keydown action by default. In our case we need to make sure that it also toggles the visibility in the store not just the native open and show dialog . 
When dialog opens it adds a top layer where all the elements are inter meaning not interactive. We want the user to be able to click outside of the cart and close the cart. For that reason we add a new click event on the dialog element where we're checking what the target is at the moment the user clicks. Anything outside of the cart is a dialog and if our check resolves to true we're closing it.
We've also tested the key navigation and it looks ok.