### PR TITLE
Add breadcrumbs to show page

### DIFF
--- a/app/helpers/pulfalight_helper.rb
+++ b/app/helpers/pulfalight_helper.rb
@@ -103,8 +103,7 @@ module PulfalightHelper
     end
 
     # Add library location to breadcrumbs
-    url = solr_document_path(document.collection_document.id) + "#access"
-    breadcrumb_links.unshift(link_to(document.repository_config&.building, url))
+    breadcrumb_links.unshift(library_location_breadcrumb(document))
 
     safe_join(breadcrumb_links, aria_hidden_breadcrumb_separator)
   end
@@ -121,8 +120,7 @@ module PulfalightHelper
     end
 
     # Add library location to breadcrumbs
-    url = solr_document_path(document.collection_document.id) + "#access"
-    breadcrumb_links.unshift(link_to(document.repository_config&.building, url))
+    breadcrumb_links.unshift(library_location_breadcrumb(document))
 
     breadcrumb_links << "&hellip;".html_safe if parents.length > 1
 
@@ -146,6 +144,21 @@ module PulfalightHelper
   end
 
   private
+
+  # Builds the leading library location breadcrumb. e.g. "Firestone Library".
+  def library_location_breadcrumb(document)
+    building = document.repository_config&.building
+    url = collection_access_path(document)
+    return building unless url
+
+    link_to(building, url)
+  end
+
+  def collection_access_path(document)
+    solr_document_path(document.collection_document.id) + "#access"
+  rescue Blacklight::Exceptions::RecordNotFound
+    nil
+  end
 
   def repository_thumbnail_path
     image_path("default_repository_thumbnail.jpg")

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -90,6 +90,13 @@ class SolrDocument
     Array.wrap(fetch("ead_ssi", nil)).first&.strip
   end
 
+  # Overrides Arclight::SolrDocument#parent_ids so that parent_ssm is used as a
+  # fallback. Item documents have parent_ssm while search results have parent_ssim.
+  def parent_ids
+    ids = fetch("parent_ssim", [])
+    ids.presence || fetch("parent_ssm", [])
+  end
+
   def collection_notes
     fetch("collection_notes_ssm", [])
   end

--- a/app/views/catalog/_component_summary.html.erb
+++ b/app/views/catalog/_component_summary.html.erb
@@ -1,4 +1,10 @@
 <div class="overview", data-component-id="<%= document.refs.first %>">
+  <% breadcrumbs = parents_to_links(document) %>
+  <% unless breadcrumbs.nil? %>
+    <div class='breadcrumb-links media'>
+      <span><%= parents_to_links(document) %></span>
+    </div>
+  <% end %>
   <div class="lux document-title">
     <h2><%= document.normalized_title %></h2>
     <div class="document-attributes">

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -63,8 +63,14 @@ describe "viewing catalog records", type: :feature, js: true do
       expect(page).to have_selector("*[data-component-id='MC221_c0060']")
     end
 
-    it "does not have breadcrumbs" do
-      expect(page).not_to have_css("ol.breadcrumb")
+    it "has breadcrumbs" do
+      within(".breadcrumb-links") do
+        expect(page).to have_link "Seeley G. Mudd Manuscript Library"
+        expect(page).to have_link "Public Policy Papers"
+        expect(page).to have_link "Harold B. Hoskins Papers, 1822-1982"
+        expect(page).to have_link "Series 1: U.S. diplomacy career, 1900-1978"
+        expect(page).to have_link "Notes, 1822-1982"
+      end
     end
 
     context "which has a viewer", js: false do


### PR DESCRIPTION
Closes #1288 

There is a lot of data duplicated in the TOC and this breadcrumb. We could make this only appear in mobile view - POs indicated that this was a primary use case. Or we could just leave it.

<img width="1451" height="1132" alt="Screenshot 2026-07-15 at 4 34 38 PM" src="https://github.com/user-attachments/assets/8665771d-f921-4ce0-a499-50c87e593ada" />