### PR TITLE
Cleanup test output

### DIFF
--- a/app/jobs/aspace_index_job.rb
+++ b/app/jobs/aspace_index_job.rb
@@ -23,7 +23,7 @@ class AspaceIndexJob < ApplicationJob
   # Construct a Traject indexer object for building Solr Documents from EADs
   # @return [Traject::Indexer::NokogiriIndexer]
   def indexer
-    indexer = Traject::Indexer::NokogiriIndexer.new(repository: @repository_id)
+    indexer = Traject::Indexer::NokogiriIndexer.new(repository: @repository_id, "logger" => logger)
     indexer.tap do |i|
       i.load_config_file(arclight_config_path)
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,14 @@ require_relative "../lib/pulfalight/middleware/no_file_uploads"
 require "rails/all"
 require_relative "lando_env"
 
+# Our current version of Blacklight depends on view_component which requires
+# active_support/configurable. That causes a Rails deprecation warning. Load
+# this dependency while silencing deprecation warnings.
+# NOTE: This can be removed when we update Blacklight.
+ActiveSupport.deprecator.silence do
+  require "active_support/configurable"
+end
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/deprecation.rb
+++ b/config/initializers/deprecation.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 Rails.application.config.after_initialize do
-  Deprecation.default_deprecation_behavior = :silence if Rails.env.production?
+  # Silence Blacklight deprecation warnings.
+  # Remove if needed for upgrading.
+  Deprecation.default_deprecation_behavior = :silence
 end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
-require "opentelemetry/sdk"
-require "opentelemetry/exporter/otlp"
-require "opentelemetry/instrumentation/rack"
-require "opentelemetry/instrumentation/rails"
-require "opentelemetry/instrumentation/active_record"
-require "opentelemetry/instrumentation/action_pack"
 
-OpenTelemetry::SDK.configure do |c|
-  c.service_name = ENV.fetch("OTEL_SERVICE_NAME", "pulmap")
+unless Rails.env.local?
+  require "opentelemetry/sdk"
+  require "opentelemetry/exporter/otlp"
+  require "opentelemetry/instrumentation/rack"
+  require "opentelemetry/instrumentation/rails"
+  require "opentelemetry/instrumentation/active_record"
+  require "opentelemetry/instrumentation/action_pack"
 
-  c.use "OpenTelemetry::Instrumentation::Rails"
-  c.use "OpenTelemetry::Instrumentation::Rack"
-  c.use "OpenTelemetry::Instrumentation::ActiveRecord"
-  c.use "OpenTelemetry::Instrumentation::ActionPack"
+  OpenTelemetry::SDK.configure do |c|
+    c.service_name = ENV.fetch("OTEL_SERVICE_NAME", "pulfalight")
+
+    c.use "OpenTelemetry::Instrumentation::Rails"
+    c.use "OpenTelemetry::Instrumentation::Rack"
+    c.use "OpenTelemetry::Instrumentation::ActiveRecord"
+    c.use "OpenTelemetry::Instrumentation::ActionPack"
+  end
 end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -83,7 +83,9 @@ describe "EAD 2 traject indexing", type: :feature do
     context "when there's not a corresponding Arclight::Repository" do
       let(:settings) do
         {
-          repository: "test"
+          repository: "test",
+          # Send log messages to /dev/null to prevent noisy test output.
+          "logger" => Logger.new(File::NULL)
         }
       end
 

--- a/spec/helpers/pulfalight_helper_spec.rb
+++ b/spec/helpers/pulfalight_helper_spec.rb
@@ -92,6 +92,21 @@ describe PulfalightHelper, type: :helper do
         end
       end
     end
+
+    describe "#display_simple_link?" do
+      it "handles bad DAOs" do
+        bad_dao = "https://webspace.princeton.edu/users/mudd/Digitization/MC001.01/MC001.01 volume 72.pdf"
+        allow(component_document).to receive(:direct_digital_objects).and_return(
+          [Arclight::DigitalObject.from_json(
+            {
+              "href" => bad_dao
+            }.to_json
+          )]
+        )
+        allow(component_document).to receive(:figgy_digital_objects).and_return(nil)
+        expect { helper.display_simple_link? }.not_to raise_error
+      end
+    end
   end
 
   describe "#hr_separator" do
@@ -105,21 +120,6 @@ describe PulfalightHelper, type: :helper do
       markup = helper.hr_separator(helper_args)
       expect(markup).not_to be nil
       expect(markup.to_s).to include("<p>\n         William Willard Thorp (1899-1990)")
-    end
-  end
-
-  describe "#display_simple_link?" do
-    it "handles bad DAOs" do
-      bad_dao = "https://webspace.princeton.edu/users/mudd/Digitization/MC001.01/MC001.01 volume 72.pdf"
-      allow(component_document).to receive(:direct_digital_objects).and_return(
-        [Arclight::DigitalObject.from_json(
-          {
-            "href" => bad_dao
-          }.to_json
-        )]
-      )
-      allow(component_document).to receive(:figgy_digital_objects).and_return(nil)
-      expect { helper.display_simple_link? }.not_to raise_error
     end
   end
 

--- a/spec/jobs/sync_to_figgy_job_spec.rb
+++ b/spec/jobs/sync_to_figgy_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SyncToFiggyJob do
         config.delete("figgy_auth_token")
         allow(Pulfalight).to receive(:config).and_return(config)
         # do not stub wemock, expect the connection to not be attempted
-        expect { described_class.perform_now(["C0001"]) }.not_to raise_error(WebMock::NetConnectNotAllowedError)
+        expect { described_class.perform_now(["C0001"]) }.not_to raise_error
       end
     end
   end

--- a/spec/requests/catalog_request_spec.rb
+++ b/spec/requests/catalog_request_spec.rb
@@ -171,14 +171,14 @@ describe "controller requests", type: :request do
   describe "searching for box and folder number", js: false do
     it "returns it" do
       get "/catalog", params: { q: "MC221 Box 1 Folder 4", search_field: "all_fields" }
-      expect(assigns.fetch(:document_list, []).map(&:id).first).to eq "MC221_c0004"
+      expect(assigns.fetch(:response).documents.map(&:id).first).to eq "MC221_c0004"
     end
   end
 
   describe "searching for a collection name", js: false do
     it "boosts collections" do
       get "/catalog", params: { q: "Lilienthal", search_field: "all_fields" }
-      expect(assigns.fetch(:document_list, []).map(&:id).first).to eq "MC148"
+      expect(assigns.fetch(:response).documents.map(&:id).first).to eq "MC148"
     end
   end
 
@@ -186,7 +186,7 @@ describe "controller requests", type: :request do
     it "returns a match for names in the wrong order" do
       get "/catalog", params: { q: '"Frederick Vinton"', search_field: "all_fields" }
 
-      results = assigns.fetch(:document_list).map(&:id)
+      results = assigns.fetch(:response).documents.map(&:id)
 
       expect(results.length).to eq 1
     end
@@ -196,14 +196,14 @@ describe "controller requests", type: :request do
     it "returns a match for separate parts in the hierarchy" do
       get "/catalog", params: { q: "wilson suffrage", search_fields: "all_fields" }
 
-      results = assigns.fetch(:document_list).map(&:id)
+      results = assigns.fetch(:response).documents.map(&:id)
 
       expect(results).to include("MC168_c02041")
     end
     it "returns a match for series titles", js: false do
       get "/catalog", params: { q: "Bernard Baruch", search_fields: "all_fields" }
 
-      results = assigns.fetch(:document_list).map(&:id)
+      results = assigns.fetch(:response).documents.map(&:id)
 
       expect(results).to include("MC016_c1866")
     end
@@ -213,7 +213,7 @@ describe "controller requests", type: :request do
     it "returns a match even if there's no 's" do
       get "/catalog", params: { q: "Woodrow Wilson", search_fields: "all_fields", per_page: 100 }
 
-      results = assigns.fetch(:document_list).map(&:id)
+      results = assigns.fetch(:response).documents.map(&:id)
 
       expect(results).to include "AC259_c005"
     end
@@ -222,7 +222,7 @@ describe "controller requests", type: :request do
   describe "searching by creator", js: false do
     it "returns components with matching creators" do
       get "/catalog", params: { q: "O'Sullivan", search_fields: "all_fields", per_page: 100 }
-      results = assigns.fetch(:document_list).map(&:id)
+      results = assigns.fetch(:response).documents.map(&:id)
       expect(results).to include "WC064_c2698"
     end
   end
@@ -230,7 +230,7 @@ describe "controller requests", type: :request do
   describe "searching by an archaic subject term", js: false do
     it "returns components with matching subject but does not display archaic subject text hightlight" do
       get "/catalog", params: { q: "Indians of North America", search_fields: "all_fields", per_page: 100 }
-      results = assigns.fetch(:document_list).map(&:id)
+      results = assigns.fetch(:response).documents.map(&:id)
       expect(results).to include "WC064_c1"
       expect(response.body).not_to have_selector "div.al-document-highlight", text: /Indians of North America/
     end


### PR DESCRIPTION
Closes #1703

Silences deprecations and unneeded messages.

Test output is much cleaner:
```
Randomized with seed 31881
............................................................................Capybara starting Puma...
* Version 5.6.9, codename: Birdie's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:44849
.................................................................................*...............*..........................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) EAD 2 traject indexing #volume_ssm indexes extent values encoding volume numbers
     # Temporarily skipped with xit
     # ./spec/features/traject/ead2_indexing_spec.rb:807

  2) EAD 2 traject indexing #physdesc_number_ssm indexes physical description values encoding material numbers
     # Temporarily skipped with xit
     # ./spec/features/traject/ead2_indexing_spec.rb:821


Finished in 4 minutes 23 seconds (files took 5.27 seconds to load)
472 examples, 0 failures, 2 pending
```