### PR TITLE
1714 cart click close

### DIFF
--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -1,7 +1,7 @@
 <template>
 
   <transition name="slide">
-    <dialog ref="dialog" class="request-cart" @close="syncVisibilityAfterNativeClose" @click="handleDialogClick">
+    <dialog ref="dialog" class="request-cart" @close="syncVisibilityAfterNativeClose" @click.self="closeDialog">
   
     <div class="panel">
       <table :class="['lux-data-table', 'fixed-header']">
@@ -230,15 +230,21 @@ export default {
     }
   },
   methods: {
-    handleDialogClick(event) {
-      if (event.target === this.$refs.dialog) {
-        this.toggleCartView()
-      }
+    closeDialog(event) {
+      console.log("closeDialog event", event)
+      console.log(event.currentTarget)
+
+      event.currentTarget.close()
+
+      //this.toggleCartView(event)
     },
     syncVisibilityAfterNativeClose() {
+      console.log("syncVisibilityAfterNativeClose before commit", this.$store.state.cart.isVisible, this.$refs.dialog.open)
       if (this.$store.state.cart.isVisible && !this.$refs.dialog.open) {
+        console.log("syncVisibilityAfterNativeClose committing TOGGLE_VISIBILITY")
         this.$store.commit("TOGGLE_VISIBILITY")
       }
+      console.log("syncVisibilityAfterNativeClose after commit", this.$store.state.cart.isVisible, this.$refs.dialog.open)
     },
     displayContainers(containers) {
       let displayString = containers.map(function(container) {
@@ -289,6 +295,11 @@ export default {
   max-height: 50px;
   overflow: hidden;
 }
+
+.request-cart::backdrop {
+   background: transparent;
+}
+
 .lux-data-table {
   table-layout: fixed;
   width: 100%;

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -231,20 +231,12 @@ export default {
   },
   methods: {
     closeDialog(event) {
-      console.log("closeDialog event", event)
-      console.log(event.currentTarget)
-
       event.currentTarget.close()
-
-      //this.toggleCartView(event)
     },
     syncVisibilityAfterNativeClose() {
-      console.log("syncVisibilityAfterNativeClose before commit", this.$store.state.cart.isVisible, this.$refs.dialog.open)
       if (this.$store.state.cart.isVisible && !this.$refs.dialog.open) {
-        console.log("syncVisibilityAfterNativeClose committing TOGGLE_VISIBILITY")
         this.$store.commit("TOGGLE_VISIBILITY")
       }
-      console.log("syncVisibilityAfterNativeClose after commit", this.$store.state.cart.isVisible, this.$refs.dialog.open)
     },
     displayContainers(containers) {
       let displayString = containers.map(function(container) {


### PR DESCRIPTION
related to #1714

I tried making the dialog size smaller and same as the panel using the pseudo attribute backtrop but didn't close the cart on a backtrop click. The online references I came across for the native dialog all described a fix for the backtrop click using javascript. 
The PR simplifies the click action: now it happens on the dialog and uses the native dialog close. That way it also lets the close handler to update the state TOGGLE_VISIBILITY.

The css to change the dialog background to transparent is just for display . The dialog's size remains the same as a top layer. 