### PR TITLE
[#1722] Use vanilla JS event instead of vuex mutation to open/toggle the cart

### DIFF
--- a/app/javascript/components/CartViewToggle.vue
+++ b/app/javascript/components/CartViewToggle.vue
@@ -32,7 +32,7 @@ export default {
   },
   methods: {
     toggleCartView(event) {
-      this.$store.commit("TOGGLE_VISIBILITY")
+      document.dispatchEvent(new Event('TOGGLE_CART'))
     }
   }
 }

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -233,6 +233,18 @@ export default {
     closeDialog(event) {
       event.currentTarget.close()
     },
+    openDialog(event) {
+      this.$nextTick(() => {
+        const dialog = this.$refs.dialog
+        if (!dialog.open) {
+            dialog.showModal()
+
+          this.$nextTick(() => {
+            this.$refs.closeCart?.$el?.focus?.()
+          })
+        }
+      })
+    },
     syncVisibilityAfterNativeClose() {
       if (this.$store.state.cart.isVisible && !this.$refs.dialog.open) {
         this.$store.commit("TOGGLE_VISIBILITY")
@@ -261,6 +273,21 @@ export default {
     removeFromCart(item) {
       this.$store.dispatch("removeItemFromCart", item)
     },
+    toggle() {
+      this.$nextTick(() => {
+        const dialog = this.$refs.dialog
+        if (dialog) {
+          if (!dialog.open) {
+              dialog.showModal()
+            this.$nextTick(() => {
+              this.$refs.closeCart?.$el?.focus?.()
+            })
+          } else {
+            dialog.close()
+          }
+        }
+      })
+    },
     toggleCartView(event) {
       console.log("togglecartview event", event)
       this.$store.commit("TOGGLE_VISIBILITY")
@@ -273,6 +300,10 @@ export default {
         this.$refs.shadowForm.submit()
       })
     }
+  },
+  created() {
+    document.addEventListener('TOGGLE_CART', () => {this.toggle()})
+    document.addEventListener('OPEN_CART', () => {this.openDialog()})
   }
 }
 </script>

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -1,7 +1,7 @@
 <template>
 
   <transition name="slide">
-    <dialog ref="dialog" class="request-cart" @close="syncVisibilityAfterNativeClose" @click.self="closeDialog">
+    <dialog ref="dialog" class="request-cart" @click.self="closeDialog">
   
     <div class="panel">
       <table :class="['lux-data-table', 'fixed-header']">
@@ -204,51 +204,25 @@ export default {
   computed: {
     requests() {
       return this.$store.state.cart.items
-    },
-    isVisible: {
-      get() {
-        return this.$store.state.cart.isVisible
-      },
-      set() {
-        this.$store.commit("TOGGLE_VISIBILITY")
-      }
-    }
-  },
-  watch: {
-    isVisible(newIsVisible, oldIsVisible) {
-      const dialog = this.$refs.dialog
-      if (newIsVisible) {
-        if (!dialog.open) {
-          dialog.showModal()
-        }
-        this.$nextTick(() => {
-          this.$refs.closeCart?.$el?.focus?.()
-        })
-      } else if (dialog.open) {
-        dialog.close()
-      }
     }
   },
   methods: {
-    closeDialog(event) {
-      event.currentTarget.close()
+    closeDialog() {
+      this.$refs.dialog?.close()
     },
-    openDialog(event) {
+    openDialog() {
       this.$nextTick(() => {
         const dialog = this.$refs.dialog
-        if (!dialog.open) {
-            dialog.showModal()
+        if (dialog) {
+          if (!dialog.open) {
+              dialog.showModal()
 
-          this.$nextTick(() => {
-            this.$refs.closeCart?.$el?.focus?.()
-          })
+            this.$nextTick(() => {
+              this.$refs.closeCart?.$el?.focus?.()
+            })
+          }
         }
       })
-    },
-    syncVisibilityAfterNativeClose() {
-      if (this.$store.state.cart.isVisible && !this.$refs.dialog.open) {
-        this.$store.commit("TOGGLE_VISIBILITY")
-      }
     },
     displayContainers(containers) {
       let displayString = containers.map(function(container) {
@@ -301,9 +275,10 @@ export default {
       })
     }
   },
-  created() {
+  mounted() {
     document.addEventListener('TOGGLE_CART', () => {this.toggle()})
     document.addEventListener('OPEN_CART', () => {this.openDialog()})
+    document.addEventListener('CLOSE_CART', () => {this.closeDialog()})
   }
 }
 </script>

--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -9,7 +9,7 @@
         <caption>
 
           <lux-input-button
-            v-on:click="toggleCartView($event)"
+            v-on:click="closeDialog()"
             width="26px"
             type="button"
             variation="text"
@@ -211,18 +211,16 @@ export default {
       this.$refs.dialog?.close()
     },
     openDialog() {
-      this.$nextTick(() => {
-        const dialog = this.$refs.dialog
-        if (dialog) {
-          if (!dialog.open) {
-              dialog.showModal()
+      const dialog = this.$refs.dialog
+      if (dialog) {
+        if (!dialog.open) {
+            dialog.showModal()
 
-            this.$nextTick(() => {
-              this.$refs.closeCart?.$el?.focus?.()
-            })
-          }
+          this.$nextTick(() => {
+            this.$refs.closeCart?.$el?.focus?.()
+          })
         }
-      })
+      }
     },
     displayContainers(containers) {
       let displayString = containers.map(function(container) {
@@ -248,23 +246,17 @@ export default {
       this.$store.dispatch("removeItemFromCart", item)
     },
     toggle() {
-      this.$nextTick(() => {
-        const dialog = this.$refs.dialog
-        if (dialog) {
-          if (!dialog.open) {
-              dialog.showModal()
-            this.$nextTick(() => {
-              this.$refs.closeCart?.$el?.focus?.()
-            })
-          } else {
-            dialog.close()
-          }
+      const dialog = this.$refs.dialog
+      if (dialog) {
+        if (!dialog.open) {
+            dialog.showModal()
+          this.$nextTick(() => {
+            this.$refs.closeCart?.$el?.focus?.()
+          })
+        } else {
+          dialog.close()
         }
-      })
-    },
-    toggleCartView(event) {
-      console.log("togglecartview event", event)
-      this.$store.commit("TOGGLE_VISIBILITY")
+      }
     },
     clearForm() {
       this.shadowRequests = this.requests

--- a/app/javascript/store/cart/index.es6
+++ b/app/javascript/store/cart/index.es6
@@ -3,6 +3,7 @@ export const cartState = {
   isVisible: false
 }
 
+
 export const cartActions = {
   addItemToCart(context, newItem) {
     const duplicate = context.state.items.find(item => item.callnumber === newItem.callnumber)
@@ -10,8 +11,7 @@ export const cartActions = {
       context.commit("PUSH_ITEM_TO_CART", newItem)
     }
 
-    if(context.state.isVisible === false)
-      context.commit("TOGGLE_VISIBILITY")
+    document.dispatchEvent(new Event('OPEN_CART'))
   },
   removeItemFromCart(context, item) {
     context.commit("REMOVE_ITEM_FROM_CART", item)
@@ -21,10 +21,6 @@ export const cartActions = {
 }
 
 export const cartMutations = {
-  TOGGLE_VISIBILITY(state) {
-    state.isVisible = !state.isVisible
-  },
-
   SET_CART(state, items) {
     state.items = items
   },

--- a/app/javascript/store/cart/index.es6
+++ b/app/javascript/store/cart/index.es6
@@ -1,6 +1,5 @@
 export const cartState = {
-  items: [],
-  isVisible: false
+  items: []
 }
 
 
@@ -15,8 +14,8 @@ export const cartActions = {
   },
   removeItemFromCart(context, item) {
     context.commit("REMOVE_ITEM_FROM_CART", item)
-    if(context.state.isVisible === true && context.state.items.length === 0)
-      context.commit("TOGGLE_VISIBILITY")
+    if(context.state.items.length === 0)
+      document.dispatchEvent(new Event('CLOSE_CART'))
   }
 }
 

--- a/app/javascript/test/cartViewToggle.spec.js
+++ b/app/javascript/test/cartViewToggle.spec.js
@@ -5,15 +5,13 @@ import { createStore } from 'vuex'
 
 describe('CartViewToggle.vue', () => {
   test('Toggling cart', async () => {
-    const toggleVisibility = vi.fn()
+    let cartToggled = false
+    document.addEventListener('TOGGLE_CART', () => { cartToggled = true })
     const newStore = {
       state: {
         cart: {
           items: [{}]
         }
-      },
-      mutations: {
-        TOGGLE_VISIBILITY: toggleVisibility
       }
     }
     const mergedStore = createStore({ ...store, ...newStore })
@@ -24,7 +22,7 @@ describe('CartViewToggle.vue', () => {
     })
     const button = getByRole('button')
     await fireEvent.click(button)
-    expect(toggleVisibility).toHaveBeenCalled()
+    expect(cartToggled).toBe(true)
 
     const count = container.getElementsByClassName('badge')[0]
     expect(count.textContent.trim()).toBe('1')

--- a/app/javascript/test/requestCart.spec.js
+++ b/app/javascript/test/requestCart.spec.js
@@ -230,11 +230,47 @@ describe('RequestCart.vue', () => {
     })
     expect(container.querySelector('.request-cart[open]')).toBeFalsy()
 
-    mergedStore.commit('TOGGLE_VISIBILITY')
+    document.dispatchEvent(new Event('TOGGLE_CART'))
     await flushPromises()
     expect(container.querySelector('.request-cart[open]')).toBeTruthy()
 
     await fireEvent.click(container.querySelector('dialog'))
     expect(container.querySelector('.request-cart[open]')).toBeFalsy()
+  })
+
+  test('it opens the cart when it hears the OPEN_CART event', async () => {
+    const customStore = {
+      modules: {
+        cart: {
+          state: {
+            items: [],
+            isVisible: false
+          },
+          actions: cartActions,
+          mutations: cartMutations
+        }
+      }
+    }
+    const mergedStore = createStore({ ...store, ...customStore })
+    const { container } = render(RequestCart, {
+      global: {
+        plugins: [mergedStore],
+        components: {
+          'lux-input-button': LuxInputButton,
+          'lux-input-text': LuxInputText
+        }
+      },
+      props: {
+        configuration: {},
+        globalFormParams: {
+          SystemID: 'Pulfa'
+        }
+      }
+    })
+    expect(container.querySelector('.request-cart[open]')).toBeFalsy()
+
+    document.dispatchEvent(new Event('OPEN_CART'))
+    await flushPromises()
+    expect(container.querySelector('.request-cart[open]')).toBeTruthy()
   })
 })


### PR DESCRIPTION
This avoids the problem of #1722 by making sure that `index.js` does not have to monitor the state of whether the cart dialog is open or closed.

The goal is that we don't have to maintain the same state between the native dialog element and Vuex, we can just listen for specific events that tell us what we need to do in the component.

Closes #1722 