### PR TITLE
Use fully qualified domain names for deploy

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 set :rails_env, "production"
 
-server "pulfalight-jammy-prod1", user: "deploy", roles: %w[app db web production_db]
-server "pulfalight-jammy-prod2", user: "deploy", roles: %w[app web]
-server "pulfalight-prod-worker1", user: "deploy", roles: %w[app worker]
+server "pulfalight-jammy-prod1.princeton.edu", user: "deploy", roles: %w[app db web production_db]
+server "pulfalight-jammy-prod2.princeton.edu", user: "deploy", roles: %w[app web]
+server "pulfalight-prod-worker1.princeton.edu", user: "deploy", roles: %w[app worker]


### PR DESCRIPTION
You need these when deploying from a local machine (or doing deploy:rollback, which is what we were doing when we discovered this problem)