### PR TITLE
Update section Storage note to display 'ReCAP - Remote Storage'

### DIFF
--- a/config/location_codes.yml
+++ b/config/location_codes.yml
@@ -27,21 +27,21 @@ mudd:
   label: 'Mudd Manuscript Library'
   url: 'https://library.princeton.edu/special-collections/visit-us'
 rcppa:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 rcppf:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 rcpph:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 rcpxc:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 rcpxg:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 rcpxm:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 rcpxr:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 selectors:
-  label: 'ReCAP'
+  label: 'ReCAP - Remote Storage'
 flm:
   <<: *firestone
 st:

--- a/spec/features/catalog_view_spec.rb
+++ b/spec/features/catalog_view_spec.rb
@@ -398,7 +398,7 @@ describe "viewing catalog records", type: :feature, js: true do
       it "displays the summary storage notes at the collection level" do
         visit "catalog/C1491"
         expect(page).to have_content("Storage Note:")
-        expect(page).to have_content("This is stored in multiple locations.\nFirestone Library (scahsvm)Boxes 1; 32; 319Firestone Library (scamss)Boxes 12; 83; 330; B-001491ReCAP (scarcpxm)Box 232")
+        expect(page).to have_content("This is stored in multiple locations.\nFirestone Library (scahsvm)Boxes 1; 32; 319Firestone Library (scamss)Boxes 12; 83; 330; B-001491ReCAP - Remote Storage (scarcpxm)Box 232")
       end
       it "displays consecutive boxes as a range" do
         visit "catalog/C1643"
@@ -410,7 +410,7 @@ describe "viewing catalog records", type: :feature, js: true do
         expect(page).to have_content("Storage Note:")
         expect(page).to have_selector("span", text: "This is stored in multiple locations.")
         expect(page).to have_selector("dl", text: "Firestone Library (scamss)Boxes B-001615 to B-001618, P-000162")
-        expect(page).to have_selector("dl", text: "ReCAP (scarcpxm)Boxes 1-2")
+        expect(page).to have_selector("dl", text: "ReCAP - Remote Storage (scarcpxm)Boxes 1-2")
       end
       it "displays a Visit Us link on the access and use tab" do
         visit "catalog/C1491"

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -152,7 +152,7 @@ describe "EAD 2 traject indexing", type: :feature do
       expect(json.keys).not_to include("This is stored in multiple locations.")
       expect(json["Firestone Library (scahsvm)"]).to include("Boxes 1; 32; 319")
       expect(json["Firestone Library (scamss)"]).to include("Boxes 12; 83; 330; B-001491")
-      expect(json["ReCAP (scarcpxm)"]).to include("Box 232")
+      expect(json["ReCAP - Remote Storage (scarcpxm)"]).to include("Box 232")
     end
 
     it "constructs component and series level summary storage notes" do
@@ -215,7 +215,7 @@ describe "EAD 2 traject indexing", type: :feature do
 
       it "displays an item count instead" do
         component = find_component(result, "AC297_c2")
-        expect(component["summary_storage_note_ssm"]).to eq ["{\"ReCAP (rcpph)\":[\"2187 individual items\"]}"]
+        expect(component["summary_storage_note_ssm"]).to eq ["{\"ReCAP - Remote Storage (rcpph)\":[\"2187 individual items\"]}"]
       end
     end
   end

--- a/spec/lib/pulfalight/normalized_box_locations_spec.rb
+++ b/spec/lib/pulfalight/normalized_box_locations_spec.rb
@@ -15,13 +15,13 @@ describe Pulfalight::NormalizedBoxLocations do
   let(:human_readable_box_locations) do
     { "Firestone Library (hsvm)" => ["Boxes 1-11; 13-17; 221; 323", "Volumes 42-45"],
       "Firestone Library (mss)" => ["Boxes 12; 20-21; 292-293; P-000145"],
-      "ReCAP (rcpxm)" => ["Boxes 105; 114; 255; 266"] }
+      "ReCAP - Remote Storage (rcpxm)" => ["Boxes 105; 114; 255; 266"] }
   end
 
   # Per conversation with Christa Cleeton, include translated location name and code
   # so that end users and staff can both get the info they need.
   it "translates the location codes" do
-    expect(normalized_box_locations.locations).to contain_exactly("Firestone Library (hsvm)", "Firestone Library (mss)", "ReCAP (rcpxm)")
+    expect(normalized_box_locations.locations).to contain_exactly("Firestone Library (hsvm)", "Firestone Library (mss)", "ReCAP - Remote Storage (rcpxm)")
   end
 
   it "generates a human readable summary of the box locations" do
@@ -65,7 +65,7 @@ describe Pulfalight::NormalizedBoxLocations do
       { "rcpxm" => { "box" => ["4", "10", "10", "10", "10", "10", "10", "10", "10", "10", "10", "4", "10", "10", "10", "11", "11", "11", "4", "4", "11", "4", "11", "11", "11", "11", "11", "11", "11", "11", "11", "4", "11", "11", "4", "11", "11", "11", "11", "11", "11", "11", "11", "11", "11", "4", "11", "11", "11", "11", "11", "4", "4", "4", "4", "11", "11", "11", "4", "11", "11", "11", "12", "12", "11", "11", "12", "12", "12", "12", "12", "12", "4", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "12", "4", "12", "12", "12", "12", "12", "12", "4", "4", "4", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "4", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "13", "5", "5", "5", "5", "5", "5", "5", "5", "5", "13", "13", "13", "5", "5", "5", "5", "5", "5", "5", "5", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "6", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "7", "8", "8", "13", "8", "8", "8", "8", "9", "8", "8", "8"] }, "location_under_review" => { "item" => ["32101047385792", "32101086138714"] } }
     end
     it "doesn't hang forever" do
-      expect(normalized_box_locations.to_h).to eq({ "ReCAP (rcpxm)" => ["Boxes 4-13"], "location_under_review" => ["Items 32101047385792; 32101086138714"] })
+      expect(normalized_box_locations.to_h).to eq({ "ReCAP - Remote Storage (rcpxm)" => ["Boxes 4-13"], "location_under_review" => ["Items 32101047385792; 32101086138714"] })
     end
   end
 end


### PR DESCRIPTION
related to #1595
This commit updates the display only in the storage note in the show page. There is no change in the cart. 