### PR TITLE
Add hit highlighting to grouped results

### DIFF
--- a/app/views/catalog/_arclight_index_group_document_default.html.erb
+++ b/app/views/catalog/_arclight_index_group_document_default.html.erb
@@ -17,13 +17,21 @@
           <span class="media-body" aria-hidden="true"><%= blacklight_icon :folder, classes: 'al-folder-icon' %></span>
           <span class="col" ><%= parents_to_links(document) %></span>
         <% end %>
-    </div>
-    <% # Start PUL Customizations %>
-    <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
-      <%= content_tag('div', 'data-arclight-truncate' => true) do %>
-        <%= document.abstract_or_scope %>
-      <% end %>
-    <% end if document.abstract_or_scope %>
+      </div>
+      <% # Start PUL Customizations %>
+      <div class="row">
+        <%= content_tag('div', class: 'al-document-highlight col') do %>
+          <%= document.highlights.join('<br/>').html_safe %>
+          <% end if document.highlights %>
+      </div>
+
+      <div class="row">
+        <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
+          <%= content_tag('div', 'data-arclight-truncate' => true) do %>
+            <%= document.abstract_or_scope %>
+          <% end %>
+          <% end if document.abstract_or_scope %>
+      </div>
     <% # End PUL Customizations %>
   </div>
 </article>

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -211,4 +211,26 @@ describe "catalog searches", type: :feature, js: true do
       end
     end
   end
+
+  describe "hit highlighting" do
+    context "in the grouped results" do
+      it "shows highlighted terms" do
+        visit "/catalog?q=photograph&group=true"
+
+        within first("article") do
+          expect(page).to have_selector(".al-document-highlight em", text: "Photographs")
+        end
+      end
+    end
+
+    context "in 'all results'" do
+      it "shows highlighted terms" do
+        visit "/catalog?q=photograph&group=false"
+
+        within first("article") do
+          expect(page).to have_selector(".al-document-highlight em", text: "Photographs")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #555

Screenshot: 
<img width="1051" height="1176" alt="Screenshot 2026-07-20 at 4 22 37 PM" src="https://github.com/user-attachments/assets/2a00730a-4a66-4299-859a-2ab71c50b612" />
