### PR TITLE
Down-weight parent_unittitles_teim so matches on own values are boosted

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -101,7 +101,8 @@
          parent_identifier_match
          prefercite_teim
          text_en
-         parent_unittitles_teim
+         <!-- Down-weight parent_ fields. See pulfalight#1722 -->
+         parent_unittitles_teim^0.5
          text
        </str>
        <str name="pf">

--- a/spec/requests/search_relevance_spec.rb
+++ b/spec/requests/search_relevance_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "search relevance", type: :request do
+  context "when a document matches only through the parent document title" do
+    it "is ranked below a document that matches on it's own values" do
+      get "/catalog.json?q=beloved&search_field=all_fields"
+      ids = JSON.parse(response.body)["data"].map { |doc| doc["id"] }
+
+      # Smith, James McCune, 1985 February
+      # Parent title is "Beloved Research Files, 1985-1986"
+      parent_title_match = "C1491_c68"
+
+      # Cyrano (unpublished), 1976
+      # scopecontent_ssm contains the word "beloved"
+      own_field_match = "ref293"
+      expect(ids).to include(parent_title_match, own_field_match)
+      expect(ids.index(own_field_match)).to be < ids.index(parent_title_match)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1733 

The components with "dogs" in their titles are boosted above components whose parents have "dogs" in their titles but not in their own.

<img width="1127" height="1049" alt="image" src="https://github.com/user-attachments/assets/598978bb-e0ef-420b-8a83-799a96b5aba8" />

https://findingaids-staging.princeton.edu/catalog?q=dogs&search_field=all_field 
VS.
https://findingaids.princeton.edu/catalog?q=Dogs&search_field=all_fields

https://findingaids-staging.princeton.edu/catalog?group=true&search_field=all_fields&q=dogs
VS.
https://findingaids.princeton.edu/catalog?group=true&q=Dogs&search_field=all_fields