### PR TITLE
Fix header and footer in expaned view

### DIFF
--- a/app/views/catalog/_show_collection_expanded.html.erb
+++ b/app/views/catalog/_show_collection_expanded.html.erb
@@ -37,7 +37,7 @@
       </div><!-- /.col-md-12 -->
     </div><!-- /.row.content-navigation -->
 
-    <div class="row content-container">
+    <div id="toc-container" class="row content-container">
       <div class="col-md-4">
         <div class="toc-header">
           <div class="toc-header-text">
@@ -53,6 +53,16 @@
               <span class="toggle-icon"></span>
             </a>
           </div>
+        </div>
+        <div class="toc-online-toggle al-online-material-icon">
+          <%= blacklight_icon(:online) %>
+          <label for="tocOnlineToggle" class="online-toggle-label">
+            <span> Only show material containing online material </span>
+           <div class="toggle">
+              <input type="checkbox" id="tocOnlineToggle">
+              <span class="toc-slider"></span>
+          </div>
+          </label>
         </div>
         <div id="toc" data-turbolinks-permanent class="collapse show"></div>
         <div id="toc-data" data-selected="<%= document.id %>"></div>

--- a/spec/features/expanded_collection_view_spec.rb
+++ b/spec/features/expanded_collection_view_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "expanded collection view", type: :feature, js: true do
+  it "renders the header and footer" do
+    visit "/catalog/MC221?expanded=true"
+
+    expect(page).to have_link("Princeton University Library", href: "https://library.princeton.edu")
+    expect(page).to have_link("Accessibility", href: "https://accessibility.princeton.edu/help")
+  end
+
+  it "renders the online-material toggle" do
+    visit "/catalog/MC221?expanded=true"
+
+    expect(page).to have_css(".toc-online-toggle")
+    expect(page).to have_css("#tocOnlineToggle", visible: :all)
+  end
+end


### PR DESCRIPTION
Closes #1577 

The TOC looks for the toggle when setting up. It raised an error which stopped other JS from loading, including the LUX elements.