### PR TITLE
Increase color contrast in page header cart count badge

### DIFF
--- a/app/javascript/components/CartViewToggle.vue
+++ b/app/javascript/components/CartViewToggle.vue
@@ -43,7 +43,7 @@ export default {
 #count {
   font-size: 12px;
   font-family: style.$font-family-text;
-  background: #ff0000;
+  background: style.$color-red;
   color: #fff;
   padding: 0 5px;
   vertical-align: super;


### PR DESCRIPTION
Closes #1737 

The count badge is now a set to the darker system red. The contrast is 5.53:1 instead of 3.99:1.

<img width="585" height="426" alt="image" src="https://github.com/user-attachments/assets/3bcd34ca-eb7b-4d3a-96b7-1a720cef1f07" />
