### PR TITLE
Add conformant fallback background color to home page

### DIFF
--- a/app/assets/stylesheets/layouts/home.scss
+++ b/app/assets/stylesheets/layouts/home.scss
@@ -1,5 +1,6 @@
 .header__secondary.home-header {
   position: relative;
+  background-color: $dark-gray;
   h1 {
     color: #ffffff;
     position: relative;


### PR DESCRIPTION
Closes #1739 

Before:
<img width="1514" height="805" alt="image" src="https://github.com/user-attachments/assets/ea9b087f-60df-4ed3-95d0-8e33bf729088" />


After:
<img width="1526" height="760" alt="image" src="https://github.com/user-attachments/assets/75cd2bc4-7bf0-4e75-8bc4-82dbcdf85930" />
