### PR TITLE
Show more of the data table within the cart

### DIFF
--- a/app/javascript/components/RequestCart.vue
+++ b/app/javascript/components/RequestCart.vue
@@ -352,8 +352,8 @@ export default {
 .lux-data-table tbody{
   display:block;
   width: 100%;
-  overflow: auto;
-  height: calc(100% - 162px);
+  height: calc(100% - 60px);
+  overflow: scroll;
 }
 
 .lux-data-table tr {


### PR DESCRIPTION
I tried this at a variety of zoom levels and it looked consistent.

fixes #1821

before:
<img width="300" alt="Screenshot 2026-08-18 at 1 46 17 PM" src="https://github.com/user-attachments/assets/56056719-11eb-4ad3-92ab-3af9007e5b9c" />

after:
<img width="300" alt="Screenshot 2026-08-18 at 2 11 32 PM" src="https://github.com/user-attachments/assets/1ff58ff7-df84-46bf-baec-c82e3432aeee" />

super zoomed-in, after:

<img width="300" alt="Screenshot 2026-08-18 at 2 15 08 PM" src="https://github.com/user-attachments/assets/68f1ca65-4c1c-4f3d-a037-32ece70a7ebd" />

